### PR TITLE
Use platform-agnostic dir separator

### DIFF
--- a/src/qt/mainwindow.cpp
+++ b/src/qt/mainwindow.cpp
@@ -27,6 +27,7 @@
 #include <QVBoxLayout>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QDir>
 
 
 using namespace std;
@@ -83,7 +84,7 @@ MainWindow::~MainWindow()
 void MainWindow::runGame(QString rom_file)
 {
     QFileInfo rom_info(rom_file);
-    QString save_file = rom_info.path() + "\\" + rom_info.completeBaseName() + ".sav";
+    QString save_file = rom_info.path() + QDir::separator() + rom_info.completeBaseName() + ".sav";
     
     if (gba != nullptr)
         delete gba;


### PR DESCRIPTION
Use Qt's QDir::separator() instead of hardcoded "\\".
This fixes saving to the same directory as the rom on systems not using
the backslash as path separator.