### PR TITLE
Explicitly set ags frag color alpha to 1

### DIFF
--- a/src/platform/core/src/device/shader/color_ags.glsl.hpp
+++ b/src/platform/core/src/device/shader/color_ags.glsl.hpp
@@ -68,5 +68,6 @@ constexpr auto color_ags_frag = R"(\
     screen = color * screen;
 
     frag_color = pow(screen, vec4(1.0 / display_gamma));
+    frag_color.a = 1;
   }
 )";


### PR DESCRIPTION
There may be a better long-term approach for NBA. For now, this resolves the issue with the GBA SP color correction that causes the window to render as transparent.