### PR TITLE
Qt: allow specifying a custom folder for save games and save states.

### DIFF
--- a/src/platform/core/include/platform/config.hpp
+++ b/src/platform/core/include/platform/config.hpp
@@ -15,6 +15,7 @@ namespace nba {
 
 struct PlatformConfig : Config {
   std::string bios_path = "bios.bin";
+  std::string save_path = "";
   
   struct Cartridge {
     BackupType backup_type = BackupType::Detect;

--- a/src/platform/core/include/platform/config.hpp
+++ b/src/platform/core/include/platform/config.hpp
@@ -15,7 +15,7 @@ namespace nba {
 
 struct PlatformConfig : Config {
   std::string bios_path = "bios.bin";
-  std::string save_path = "";
+  std::string save_folder = "";
   
   struct Cartridge {
     BackupType backup_type = BackupType::Detect;

--- a/src/platform/core/src/config.cpp
+++ b/src/platform/core/src/config.cpp
@@ -35,7 +35,7 @@ void PlatformConfig::Load(std::string const& path) {
       auto general = general_result.unwrap();
       this->bios_path = toml::find_or<std::string>(general, "bios_path", "bios.bin");
       this->skip_bios = toml::find_or<toml::boolean>(general, "bios_skip", false);
-      this->save_path = toml::find_or<std::string>(general, "save_path", "");
+      this->save_folder = toml::find_or<std::string>(general, "save_folder", "");
     }
   }
 
@@ -153,7 +153,7 @@ void PlatformConfig::Save(std::string const& path) {
   // General
   data["general"]["bios_path"] = this->bios_path;
   data["general"]["bios_skip"] = this->skip_bios;
-  data["general"]["save_path"] = this->save_path;
+  data["general"]["save_folder"] = this->save_folder;
 
   // Cartridge
   std::string save_type;

--- a/src/platform/core/src/config.cpp
+++ b/src/platform/core/src/config.cpp
@@ -35,6 +35,7 @@ void PlatformConfig::Load(std::string const& path) {
       auto general = general_result.unwrap();
       this->bios_path = toml::find_or<std::string>(general, "bios_path", "bios.bin");
       this->skip_bios = toml::find_or<toml::boolean>(general, "bios_skip", false);
+      this->save_path = toml::find_or<std::string>(general, "save_path", "");
     }
   }
 
@@ -152,6 +153,7 @@ void PlatformConfig::Save(std::string const& path) {
   // General
   data["general"]["bios_path"] = this->bios_path;
   data["general"]["bios_skip"] = this->skip_bios;
+  data["general"]["save_path"] = this->save_path;
 
   // Cartridge
   std::string save_type;

--- a/src/platform/qt/rc/config.toml
+++ b/src/platform/qt/rc/config.toml
@@ -1,7 +1,7 @@
 [general]
 bios_path = "bios.bin"
 bios_skip = false
-save_path = ""
+save_folder = ""
 
 [cartridge]
 # Possible values: detect, none, sram, flash64, flash128, eeprom512, eeprom8192

--- a/src/platform/qt/rc/config.toml
+++ b/src/platform/qt/rc/config.toml
@@ -1,6 +1,7 @@
 [general]
 bios_path = "bios.bin"
 bios_skip = false
+save_path = ""
 
 [cartridge]
 # Possible values: detect, none, sram, flash64, flash128, eeprom512, eeprom8192

--- a/src/platform/qt/src/widget/main_window.cpp
+++ b/src/platform/qt/src/widget/main_window.cpp
@@ -519,14 +519,14 @@ void MainWindow::SelectSaveFolder() {
   dialog.setFileMode(QFileDialog::Directory);
 
   if (dialog.exec()) {
-    config->save_path = dialog.selectedFiles().at(0).toStdString();
+    config->save_folder = dialog.selectedFiles().at(0).toStdString();
     config->Save();
     RenderSaveStateMenus();
   }
 }
 
 void MainWindow::RemoveSaveFolder() {
-  config->save_path = "";
+  config->save_folder = "";
   config->Save();
   RenderSaveStateMenus();
 }
@@ -830,14 +830,14 @@ auto MainWindow::SaveState(std::string const& path) -> nba::SaveStateWriter::Res
 }
 
 auto MainWindow::GetSavePath(fs::path const& rom_path, fs::path const& extension) -> fs::path {
-  fs::path save_folder_path = config->save_path;
+  fs::path save_folder = config->save_folder;
 
   if(
-   !save_folder_path.empty() &&
-    fs::exists(save_folder_path) &&
-    fs::is_directory(save_folder_path) 
+   !save_folder.empty() &&
+    fs::exists(save_folder) &&
+    fs::is_directory(save_folder) 
   ) {
-    return save_folder_path / rom_path.filename().replace_extension(extension);
+    return save_folder / rom_path.filename().replace_extension(extension);
   }
 
   return fs::path{rom_path}.replace_extension(extension);

--- a/src/platform/qt/src/widget/main_window.cpp
+++ b/src/platform/qt/src/widget/main_window.cpp
@@ -438,9 +438,7 @@ void MainWindow::RenderSaveStateMenus() {
     action_save->setShortcut(Qt::SHIFT | key);
 
     if (game_loaded) {
-      auto slot_filename = fs::path{game_path}
-        .replace_extension(fmt::format("{:02}.nbss", i))
-        .string();
+      auto slot_filename = GetSavePath(game_path, fmt::format("{:02}.nbss", i)).string();
 
       if (fs::exists(slot_filename)) {
         auto file_info = QFileInfo{QString::fromStdString(slot_filename)};
@@ -523,12 +521,14 @@ void MainWindow::SelectSaveFolder() {
   if (dialog.exec()) {
     config->save_path = dialog.selectedFiles().at(0).toStdString();
     config->Save();
+    RenderSaveStateMenus();
   }
 }
 
 void MainWindow::RemoveSaveFolder() {
   config->save_path = "";
   config->Save();
+  RenderSaveStateMenus();
 }
 
 void MainWindow::PromptUserForReset() {

--- a/src/platform/qt/src/widget/main_window.cpp
+++ b/src/platform/qt/src/widget/main_window.cpp
@@ -510,6 +510,7 @@ void MainWindow::SelectBIOS() {
   if (dialog.exec()) {
     config->bios_path = dialog.selectedFiles().at(0).toStdString();
     config->Save();
+    PromptUserForReset();
   }
 }
 
@@ -521,14 +522,14 @@ void MainWindow::SelectSaveFolder() {
   if (dialog.exec()) {
     config->save_folder = dialog.selectedFiles().at(0).toStdString();
     config->Save();
-    RenderSaveStateMenus();
+    PromptUserForReset();
   }
 }
 
 void MainWindow::RemoveSaveFolder() {
   config->save_folder = "";
   config->Save();
-  RenderSaveStateMenus();
+  PromptUserForReset();
 }
 
 void MainWindow::PromptUserForReset() {

--- a/src/platform/qt/src/widget/main_window.cpp
+++ b/src/platform/qt/src/widget/main_window.cpp
@@ -209,14 +209,14 @@ void MainWindow::CreateSystemMenu(QMenu* parent) {
     SelectSaveFolder();
   });
 
-  auto remove_save_folder_action = menu->addAction(tr("Remove save folder"));
+  auto remove_save_folder_action = menu->addAction(tr("Clear save folder"));
   connect(remove_save_folder_action, &QAction::triggered, [this]() {
     RemoveSaveFolder();
   });
 
   menu->addSeparator();
 
-  CreateSelectionOption(menu->addMenu(tr("Save Type")), {
+  CreateSelectionOption(menu->addMenu(tr("Save type")), {
     { "Detect",      nba::Config::BackupType::Detect },
     { "SRAM",        nba::Config::BackupType::SRAM   },
     { "FLASH 64K",   nba::Config::BackupType::FLASH_64  },
@@ -226,7 +226,7 @@ void MainWindow::CreateSystemMenu(QMenu* parent) {
   }, &config->cartridge.backup_type, true);
 
   CreateBooleanOption(menu, "Force RTC", &config->cartridge.force_rtc, true);
-  CreateBooleanOption(menu, "Force Solar Sensor", &config->cartridge.force_solar_sensor, true);
+  CreateBooleanOption(menu, "Force solar sensor", &config->cartridge.force_solar_sensor, true);
 
   menu->addSeparator();
 
@@ -234,7 +234,7 @@ void MainWindow::CreateSystemMenu(QMenu* parent) {
 }
 
 void MainWindow::CreateSolarSensorValueMenu(QMenu* parent) {
-  auto menu = parent->addMenu(tr("Solar Sensor Level"));
+  auto menu = parent->addMenu(tr("Solar sensor level"));
 
   current_solar_level = menu->addAction("");
   UpdateSolarSensorLevel(); // needed to update label
@@ -263,7 +263,7 @@ void MainWindow::CreateSolarSensorValueMenu(QMenu* parent) {
   connect(menu->addAction(tr("Enter value...")), &QAction::triggered, [=]() {
     SetSolarLevel(QInputDialog::getInt(
       this,
-      tr("Solar Sensor Level"),
+      tr("Solar sensor level"),
       tr("Enter a value between 0 (lowest intensity) and 255 (highest intensity)"),
       config->cartridge.solar_sensor_level, 0, 255, 1));
   });
@@ -905,6 +905,6 @@ void MainWindow::UpdateSolarSensorLevel() {
 
   if (current_solar_level) {
     current_solar_level->setText(
-      QString::fromStdString(fmt::format("Current Level: {} / 255", level)));
+      QString::fromStdString(fmt::format("Current level: {} / 255", level)));
   }
 }

--- a/src/platform/qt/src/widget/main_window.hpp
+++ b/src/platform/qt/src/widget/main_window.hpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <cmath>
 #include <functional>
+#include <filesystem>
 #include <nba/core.hpp>
 #include <platform/loader/save_state.hpp>
 #include <platform/writer/save_state.hpp>
@@ -25,6 +26,8 @@
 #include "widget/input_window.hpp"
 #include "widget/screen.hpp"
 #include "config.hpp"
+
+namespace fs = std::filesystem;
 
 struct MainWindow : QMainWindow {
   MainWindow(
@@ -122,6 +125,8 @@ private:
 
   auto LoadState(std::string const& path) -> nba::SaveStateLoader::Result;
   auto SaveState(std::string const& path) -> nba::SaveStateWriter::Result;
+
+  auto GetSavePath(fs::path const& rom_path, fs::path const& extension) -> fs::path;
 
   std::shared_ptr<Screen> screen;
   std::shared_ptr<nba::BasicInputDevice> input_device = std::make_shared<nba::BasicInputDevice>();

--- a/src/platform/qt/src/widget/main_window.hpp
+++ b/src/platform/qt/src/widget/main_window.hpp
@@ -63,6 +63,9 @@ private:
   void RenderSaveStateMenus();
 
   void SelectBIOS();
+  void SelectSaveFolder();
+  void RemoveSaveFolder();
+  void ClearSaveFolder();
   void PromptUserForReset();
 
   auto CreateBooleanOption(


### PR DESCRIPTION
This PR allows selecting a custom folder that all save games and states will be saved in.
This is the first initial implementation. A future PR should introduce a configuration window for paths, so that the user can check what path is currently configured.

![image](https://user-images.githubusercontent.com/13669774/198742342-0bf298aa-d5f7-48ac-a1b8-7b8527d96b55.png)
