### PR TITLE
PPU: implement a cycle-accurate renderer (Version 2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![license](https://img.shields.io/github/license/nba-emu/NanoBoyAdvance)
 ![build](https://img.shields.io/github/actions/workflow/status/nba-emu/NanoBoyAdvance/build.yml?branch=master)
 
-NanoBoyAdvance is a highly accurate Game Boy Advance emulator.<br>
-It aims for cycle-accurate emulation when possible, while also offering enhancements such as
+NanoBoyAdvance is a cycle-accurate Game Boy Advance emulator.<br>
+It aims to be as accurate as possible, while also offering enhancements such as
 improved audio quality.<br>
 
 ![screenshot1](docs/screenshot.png)
@@ -30,16 +30,13 @@ You can [dump](https://github.com/mgba-emu/bios-dump/tree/master/src) it from a 
 
 ## Accuracy
 
-A lot of attention to detail has been put into developing this core and making it accurate.
-Its CPU and timing emulation is more accurate than other software emulators right now. 
+A lot of research and attention to detail has been put into developing this core and making it accurate.
 
-- Cycle-accurate emulation of the CPU, DMA, timers and Game Pak prefetch buffer
+- Cycle-accurate emulation of most components, including: CPU, DMA, timers, PPU and Game Pak prefetch
 - Passes all AGS aging cartridge tests (NBA was the first public emulator to achieve this)
 - Passes most tests in the [mGBA test suite](https://github.com/mgba-emu/suite) (see [mGBA suite comparison](docs/ACCURACY.md#mGBA-suite-comparison) for more details)
 - Passes [ARMWrestler](https://github.com/destoer/armwrestler-gba-fixed), [gba-suite](https://github.com/jsmolka/gba-tests) and [FuzzARM](https://github.com/DenSinH/FuzzARM) CPU tests
-- High compatibility, including games that require emulation of peculiar hardware edge-cases (see [Game compatibility](docs/ACCURACY.md#Game-compatibility))
-
-Cycle-accurate PPU emulation is an active topic of research and will be implemented, once the timing has been understood and documented well enough.
+- Very high compatibility, including games that require emulation of peculiar hardware edge-cases (see [Game compatibility](docs/ACCURACY.md#Game-compatibility))
 
 ## Compiling
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [COMPILING.md](docs/COMPILING.md) in the `docs` folder.
 
 ## Copyright
 
-NanoBoyAdvance is Copyright © 2015 - 2022 fleroviux.<br>
+NanoBoyAdvance is Copyright © 2015 - 2023 fleroviux.<br>
 It is licensed under the terms of the GNU General Public License (GPL) 3.0 or any later version. See [LICENSE](LICENSE) for details.
 
 Game Boy Advance is a registered trademark of Nintendo Co., Ltd.

--- a/docs/ACCURACY.md
+++ b/docs/ACCURACY.md
@@ -37,10 +37,10 @@ Some of these issues are minor visual bugs, that do not affect gameplay, others 
 - Gunstar Heroes (requires limiting sprite render cycles: https://github.com/nba-emu/NanoBoyAdvance/issues/98)
 - Golden Sun (Sprite attributes are updated regardless of transparency: https://github.com/nba-emu/NanoBoyAdvance/issues/99) (minor issue)
 - Iridion 3D (BGX/BGY writes are latched at the start of the scanline: https://github.com/nba-emu/NanoBoyAdvance/issues/176) (minor issue)
-
-## Known broken
-
 - Gadget Racers (requires sub-scanline precision: https://github.com/nba-emu/NanoBoyAdvance/issues/230)
 - Metal Max Kai II (original revision) (requires sub-scanline precision: https://github.com/nba-emu/NanoBoyAdvance/issues/229) (minor issue)
 - Madden NFL 06 (requires VRAM access stalling: https://github.com/nba-emu/NanoBoyAdvance/issues/241)
+
+## Known broken
+
 - All Inside-cap visual novel ports (emulator detection gets set off: https://github.com/nba-emu/NanoBoyAdvance/issues/203)

--- a/src/nba/CMakeLists.txt
+++ b/src/nba/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES
   src/hw/ppu/registers.cpp
   src/hw/ppu/serialization.cpp
   src/hw/ppu/sprite.cpp
+  src/hw/ppu/window.cpp
   src/hw/rom/backup/eeprom.cpp
   src/hw/rom/backup/flash.cpp
   src/hw/rom/backup/serialization.cpp

--- a/src/nba/CMakeLists.txt
+++ b/src/nba/CMakeLists.txt
@@ -91,6 +91,7 @@ set(HEADERS_PUBLIC
   include/nba/common/crc32.hpp
   include/nba/common/meta.hpp
   include/nba/common/punning.hpp
+  include/nba/common/scope_exit.hpp
   include/nba/device/audio_device.hpp
   include/nba/device/input_device.hpp
   include/nba/device/video_device.hpp

--- a/src/nba/include/nba/common/compiler.hpp
+++ b/src/nba/include/nba/common/compiler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/crc32.hpp
+++ b/src/nba/include/nba/common/crc32.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/dsp/resampler.hpp
+++ b/src/nba/include/nba/common/dsp/resampler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/dsp/resampler/blep.hpp
+++ b/src/nba/include/nba/common/dsp/resampler/blep.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/dsp/resampler/cosine.hpp
+++ b/src/nba/include/nba/common/dsp/resampler/cosine.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/dsp/resampler/cubic.hpp
+++ b/src/nba/include/nba/common/dsp/resampler/cubic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/dsp/resampler/nearest.hpp
+++ b/src/nba/include/nba/common/dsp/resampler/nearest.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/dsp/resampler/sinc.hpp
+++ b/src/nba/include/nba/common/dsp/resampler/sinc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/dsp/ring_buffer.hpp
+++ b/src/nba/include/nba/common/dsp/ring_buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/dsp/stereo.hpp
+++ b/src/nba/include/nba/common/dsp/stereo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/dsp/stream.hpp
+++ b/src/nba/include/nba/common/dsp/stream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/meta.hpp
+++ b/src/nba/include/nba/common/meta.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/punning.hpp
+++ b/src/nba/include/nba/common/punning.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/common/scope_exit.hpp
+++ b/src/nba/include/nba/common/scope_exit.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 fleroviux
+ *
+ * Licensed under GPLv3 or any later version.
+ * Refer to the included LICENSE file.
+ */
+
+#pragma once
+
+namespace nba {
+
+template<typename Functor>
+struct ScopeExit {
+  ScopeExit(Functor&& fn) : fn{fn} {}
+
+  ScopeExit(ScopeExit&& other) = delete;
+  ScopeExit(ScopeExit const& other) = delete;
+
+ ~ScopeExit() { fn.operator()(); }
+
+  Functor fn;
+};
+
+} // namespace nba

--- a/src/nba/include/nba/config.hpp
+++ b/src/nba/include/nba/config.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/core.hpp
+++ b/src/nba/include/nba/core.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/device/audio_device.hpp
+++ b/src/nba/include/nba/device/audio_device.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/device/input_device.hpp
+++ b/src/nba/include/nba/device/input_device.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/device/video_device.hpp
+++ b/src/nba/include/nba/device/video_device.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/integer.hpp
+++ b/src/nba/include/nba/integer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/log.hpp
+++ b/src/nba/include/nba/log.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/backup/backup.hpp
+++ b/src/nba/include/nba/rom/backup/backup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/backup/backup_file.hpp
+++ b/src/nba/include/nba/rom/backup/backup_file.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/backup/eeprom.hpp
+++ b/src/nba/include/nba/rom/backup/eeprom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/backup/flash.hpp
+++ b/src/nba/include/nba/rom/backup/flash.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/backup/sram.hpp
+++ b/src/nba/include/nba/rom/backup/sram.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/gpio/device.hpp
+++ b/src/nba/include/nba/rom/gpio/device.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/gpio/gpio.hpp
+++ b/src/nba/include/nba/rom/gpio/gpio.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/gpio/rtc.hpp
+++ b/src/nba/include/nba/rom/gpio/rtc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/gpio/solar_sensor.hpp
+++ b/src/nba/include/nba/rom/gpio/solar_sensor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/header.hpp
+++ b/src/nba/include/nba/rom/header.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/rom/rom.hpp
+++ b/src/nba/include/nba/rom/rom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -47,6 +47,9 @@ struct SaveState {
     struct Memory {
       std::array<u8, 0x40000> wram;
       std::array<u8, 0x8000> iram;
+      u8 pram[0x00400];
+      u8 oam [0x00400];
+      u8 vram[0x18000];
       struct Latch {
         u32 bios;
       } latch;
@@ -89,44 +92,6 @@ struct SaveState {
   } irq;
 
   struct PPU {
-    /*struct IO {
-      u16 dispcnt;
-      u16 dispstat;
-      u8 vcount;
-
-      u16 bgcnt[4];
-      u16 bghofs[4];
-      u16 bgvofs[4];
-
-      struct ReferencePoint {
-        s32 initial;
-        s32 current;
-        bool written;
-      } bgx[2], bgy[2];
-
-      s16 bgpa[2];
-      s16 bgpb[2];
-      s16 bgpc[2];
-      s16 bgpd[2];
-
-      u16 winh[2];
-      u16 winv[2];
-      u16 winin;
-      u16 winout;
-
-      struct Mosaic {
-        struct {
-          u8 size_x;
-          u8 size_y;
-          u8 counter_y;
-        } bg, obj;
-      } mosaic;
-
-      u16 bldcnt;
-      u16 bldalpha;
-      u16 bldy;
-    } io;*/
-
     struct IO {
       u16 dispcnt;
       u16 greenswap;
@@ -154,10 +119,6 @@ struct SaveState {
     bool enable_bg[2][4];
     bool window_scanline_enable[2];
     bool dma3_video_transfer_running;
-
-    u8 pram[0x00400];
-    u8 oam [0x00400];
-    u8 vram[0x18000];
   } ppu;
 
   struct APU {

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -77,6 +77,7 @@ struct SaveState {
     } prefetch;
 
     int last_access;
+    int parallel_internal_cpu_cycle_limit;
   } bus;
 
   // TODO: keep track of IRQ delay:

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -116,8 +116,11 @@ struct SaveState {
       u16 bldy;
     } io;
 
-    bool enable_bg[2][4];
-    bool window_scanline_enable[2];
+    struct ReferencePoint {
+      s32  current;
+      bool written;
+    } bgx[2], bgy[2];
+
     bool dma3_video_transfer_running;
   } ppu;
 

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -89,7 +89,7 @@ struct SaveState {
   } irq;
 
   struct PPU {
-    struct IO {
+    /*struct IO {
       u16 dispcnt;
       u16 dispstat;
       u8 vcount;
@@ -122,6 +122,30 @@ struct SaveState {
         } bg, obj;
       } mosaic;
 
+      u16 bldcnt;
+      u16 bldalpha;
+      u16 bldy;
+    } io;*/
+
+    struct IO {
+      u16 dispcnt;
+      u16 greenswap;
+      u16 dispstat;
+      u16 vcount;
+      u16 bgcnt[4];
+      u16 bghofs[4];
+      u16 bgvofs[4];
+      u16 bgpa[2];
+      u16 bgpb[2];
+      u16 bgpc[2];
+      u16 bgpd[2];
+      u32 bgx[2];
+      u32 bgy[2];
+      u16 winh[2];
+      u16 winv[2];
+      u16 winin;
+      u16 winout;
+      u16 mosaic;
       u16 bldcnt;
       u16 bldalpha;
       u16 bldy;

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -16,7 +16,7 @@ namespace nba {
 
 struct SaveState {
   static constexpr u32 kMagicNumber = 0x5353424E; // NBSS
-  static constexpr u32 kCurrentVersion = 3;
+  static constexpr u32 kCurrentVersion = 4;
 
   u32 magic;
   u32 version;
@@ -76,10 +76,7 @@ struct SaveState {
       u8 countdown;
     } prefetch;
 
-    struct DMA {
-      bool active;
-      bool openbus;
-    } dma;
+    int last_access;
   } bus;
 
   // TODO: keep track of IRQ delay:

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -78,6 +78,7 @@ struct SaveState {
 
     int last_access;
     int parallel_internal_cpu_cycle_limit;
+    bool prefetch_buffer_was_disabled;
   } bus;
 
   // TODO: keep track of IRQ delay:

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/arm7tdmi.hpp
+++ b/src/nba/src/arm/arm7tdmi.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/handlers/arithmetic.inl
+++ b/src/nba/src/arm/handlers/arithmetic.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/handlers/handler16.inl
+++ b/src/nba/src/arm/handlers/handler16.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/handlers/handler32.inl
+++ b/src/nba/src/arm/handlers/handler32.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/handlers/handler32.inl
+++ b/src/nba/src/arm/handlers/handler32.inl
@@ -329,10 +329,10 @@ void ARM_SingleDataSwap(u32 instruction) {
 
   if (byte) {
     tmp = ReadByte(GetReg(base), Access::Nonsequential);
-    WriteByte(GetReg(base), (u8)GetReg(src), Access::Nonsequential);
+    WriteByte(GetReg(base), (u8)GetReg(src), Access::Nonsequential | Access::Lock);
   } else {
     tmp = ReadWordRotate(GetReg(base), Access::Nonsequential);
-    WriteWord(GetReg(base), GetReg(src), Access::Nonsequential);
+    WriteWord(GetReg(base), GetReg(src), Access::Nonsequential | Access::Lock);
   }
 
   bus.Idle();

--- a/src/nba/src/arm/handlers/memory.inl
+++ b/src/nba/src/arm/handlers/memory.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/serialization.cpp
+++ b/src/nba/src/arm/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/state.hpp
+++ b/src/nba/src/arm/state.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/tablegen/gen_arm.hpp
+++ b/src/nba/src/arm/tablegen/gen_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/tablegen/gen_thumb.hpp
+++ b/src/nba/src/arm/tablegen/gen_thumb.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/arm/tablegen/tablegen.cpp
+++ b/src/nba/src/arm/tablegen/tablegen.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -104,8 +104,7 @@ auto Bus::Read(u32 address, int access) -> T {
     }
     // PRAM (palette RAM)
     case 0x05: {
-      Step(is_u32 ? 2 : 1);
-      return hw.ppu.ReadPRAM<T>(Align<T>(address));
+      return ReadPRAM<T>(Align<T>(address));
     }
     // VRAM (video RAM)
     case 0x06: {
@@ -195,8 +194,7 @@ void Bus::Write(u32 address, int access, T value) {
     }
     // PRAM (palette RAM)
     case 0x05: {
-      Step(is_u32 ? 2 : 1);
-      hw.ppu.WritePRAM<T>(Align<T>(address), value);
+      WritePRAM<T>(Align<T>(address), value);
       break;
     }
     // VRAM (video RAM)

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -83,7 +83,7 @@ auto Bus::Read(u32 address, int access) -> T {
     last_access = access;
   }};
 
-  if(!(access & Dma) && hw.dma.IsRunning()) hw.dma.Run();
+  if(!(access & (Dma | Lock)) && hw.dma.IsRunning()) hw.dma.Run();
 
   switch (page) {
     // BIOS
@@ -178,7 +178,7 @@ void Bus::Write(u32 address, int access, T value) {
   auto page = address >> 24;
   auto is_u32 = std::is_same_v<T, u32>;
 
-  if(!(access & Dma) && hw.dma.IsRunning()) hw.dma.Run();
+  if(!(access & (Dma | Lock)) && hw.dma.IsRunning()) hw.dma.Run();
 
   switch (page) {
     // EWRAM (external work RAM)

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -32,6 +32,7 @@ void Bus::Reset() {
   hw.rcnt[0] = 0;
   hw.rcnt[1] = 0;
   hw.postflg = 0;
+  hw.prefetch_disable_bug = false;
   prefetch = {};
   last_access = 0;
   parallel_internal_cpu_cycle_limit = 0;

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -32,7 +32,7 @@ void Bus::Reset() {
   hw.rcnt[0] = 0;
   hw.rcnt[1] = 0;
   hw.postflg = 0;
-  hw.prefetch_disable_bug = false;
+  hw.prefetch_buffer_was_disabled = false;
   prefetch = {};
   last_access = 0;
   parallel_internal_cpu_cycle_limit = 0;

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -34,6 +34,7 @@ void Bus::Reset() {
   hw.postflg = 0;
   prefetch = {};
   last_access = 0;
+  parallel_internal_cpu_cycle_limit = 0;
   UpdateWaitStateTable();
 }
 
@@ -84,6 +85,8 @@ auto Bus::Read(u32 address, int access) -> T {
   }};
 
   if(!(access & (Dma | Lock)) && hw.dma.IsRunning()) hw.dma.Run();
+
+  parallel_internal_cpu_cycle_limit = 0;
 
   switch (page) {
     // BIOS
@@ -179,6 +182,8 @@ void Bus::Write(u32 address, int access, T value) {
   auto is_u32 = std::is_same_v<T, u32>;
 
   if(!(access & (Dma | Lock)) && hw.dma.IsRunning()) hw.dma.Run();
+
+  parallel_internal_cpu_cycle_limit = 0;
 
   switch (page) {
     // EWRAM (external work RAM)

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -133,7 +133,7 @@ auto Bus::Read(u32 address, int access) -> T {
       auto sequential = access & Sequential;
       bool code = access & Code;
 
-      if ((address & 0x1'FFFF) == 0) {
+      if ((address & 0x1'FFFF) == 0 || (last_access & Dma)) {
         sequential = 0;
       }
 
@@ -230,7 +230,7 @@ void Bus::Write(u32 address, int access, T value) {
 
       auto sequential = access & Sequential;
 
-      if ((address & 0x1'FFFF) == 0) {
+      if ((address & 0x1'FFFF) == 0 || (last_access & Dma)) {
         sequential = 0;
       }
 

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -133,7 +133,8 @@ auto Bus::Read(u32 address, int access) -> T {
       auto sequential = access & Sequential;
       bool code = access & Code;
 
-      if ((address & 0x1'FFFF) == 0 || (last_access & Dma)) {
+      // @todo: check if DMA forces non-sequential access when crossing page boundaries.
+      if ((address & 0x1'FFFF) == 0 || ((last_access & Dma) && !(access & Dma))) {
         sequential = 0;
       }
 
@@ -229,7 +230,8 @@ void Bus::Write(u32 address, int access, T value) {
 
       auto sequential = access & Sequential;
 
-      if ((address & 0x1'FFFF) == 0 || (last_access & Dma)) {
+      // @todo: check if DMA forces non-sequential access when crossing page boundaries.
+      if ((address & 0x1'FFFF) == 0 || ((last_access & Dma) && !(access & Dma))) {
         sequential = 0;
       }
 

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -215,8 +215,7 @@ void Bus::Write(u32 address, int access, T value) {
     }
     // VRAM (video RAM)
     case 0x06: {
-      Step(is_u32 ? 2 : 1);
-      hw.ppu.WriteVRAM<T>(Align<T>(address), value);
+      WriteVRAM<T>(Align<T>(address), value);
       break;
     }
     // OAM (object attribute map)

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -13,6 +13,8 @@
 #include "arm/arm7tdmi.hpp"
 #include "bus/bus.hpp"
 
+#include "io.hpp"
+
 namespace nba::core {
 
 Bus::Bus(Scheduler& scheduler, Hardware&& hw)
@@ -203,6 +205,9 @@ void Bus::Write(u32 address, int access, T value) {
     case 0x04: {
       Step(1);
       address = Align<T>(address);
+      if(address >= DISPCNT && address <= BLDY) {
+        hw.ppu.Sync();
+      }
       if constexpr(std::is_same_v<T,  u8>) hw.WriteByte(address, value);
       if constexpr(std::is_same_v<T, u16>) hw.WriteHalf(address, value);
       if constexpr(std::is_same_v<T, u32>) hw.WriteWord(address, value);

--- a/src/nba/src/bus/bus.cpp
+++ b/src/nba/src/bus/bus.cpp
@@ -133,7 +133,6 @@ auto Bus::Read(u32 address, int access) -> T {
       auto sequential = access & Sequential;
       bool code = access & Code;
 
-      // @todo: check if DMA forces non-sequential access when crossing page boundaries.
       if ((address & 0x1'FFFF) == 0 || ((last_access & Dma) && !(access & Dma))) {
         sequential = 0;
       }
@@ -230,7 +229,6 @@ void Bus::Write(u32 address, int access, T value) {
 
       auto sequential = access & Sequential;
 
-      // @todo: check if DMA forces non-sequential access when crossing page boundaries.
       if ((address & 0x1'FFFF) == 0 || ((last_access & Dma) && !(access & Dma))) {
         sequential = 0;
       }

--- a/src/nba/src/bus/bus.hpp
+++ b/src/nba/src/bus/bus.hpp
@@ -82,6 +82,8 @@ struct Bus {
       bool cgb = false;
     } waitcnt;
 
+    bool prefetch_disable_bug = false;
+
     enum class HaltControl {
       Run = 0,
       Stop = 1,

--- a/src/nba/src/bus/bus.hpp
+++ b/src/nba/src/bus/bus.hpp
@@ -30,7 +30,8 @@ struct Bus {
   enum Access {
     Nonsequential = 0,
     Sequential = 1,
-    Code = 2
+    Code = 2,
+    Dma = 4
   };
 
   void Reset();
@@ -109,10 +110,7 @@ struct Bus {
     int duty;
   } prefetch;
 
-  struct DMA {
-    bool active = false;
-    bool openbus = false;
-  } dma;
+  int last_access;
 
   template<typename T>
   auto Read(u32 address, int access) -> T;

--- a/src/nba/src/bus/bus.hpp
+++ b/src/nba/src/bus/bus.hpp
@@ -31,7 +31,8 @@ struct Bus {
     Nonsequential = 0,
     Sequential = 1,
     Code = 2,
-    Dma = 4
+    Dma = 4,
+    Lock = 8
   };
 
   void Reset();

--- a/src/nba/src/bus/bus.hpp
+++ b/src/nba/src/bus/bus.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/bus/bus.hpp
+++ b/src/nba/src/bus/bus.hpp
@@ -82,7 +82,7 @@ struct Bus {
       bool cgb = false;
     } waitcnt;
 
-    bool prefetch_disable_bug = false;
+    bool prefetch_buffer_was_disabled = false;
 
     enum class HaltControl {
       Run = 0,

--- a/src/nba/src/bus/bus.hpp
+++ b/src/nba/src/bus/bus.hpp
@@ -112,6 +112,7 @@ struct Bus {
   } prefetch;
 
   int last_access;
+  int parallel_internal_cpu_cycle_limit;
 
   template<typename T>
   auto Read(u32 address, int access) -> T;

--- a/src/nba/src/bus/io.cpp
+++ b/src/nba/src/bus/io.cpp
@@ -551,7 +551,7 @@ void Bus::Hardware::WriteByte(u32 address,  u8 value) {
           haltcnt = HaltControl::Stop;
         } else {
           haltcnt = HaltControl::Halt;
-          bus->Idle();
+          bus->Step(1);
         }
       }
       break;

--- a/src/nba/src/bus/io.cpp
+++ b/src/nba/src/bus/io.cpp
@@ -532,10 +532,14 @@ void Bus::Hardware::WriteByte(u32 address,  u8 value) {
       break;
     }
     case WAITCNT+1: {
+      const bool prefetch_old = waitcnt.prefetch;
       waitcnt.ws2[0] = (value >> 0) & 3;
       waitcnt.ws2[1] = (value >> 2) & 1;
       waitcnt.phi = (value >> 3) & 3;
       waitcnt.prefetch = (value >> 6) & 1;
+      if(prefetch_old && !waitcnt.prefetch) {
+        prefetch_disable_bug = true;
+      }
       bus->UpdateWaitStateTable();
       break;
     }

--- a/src/nba/src/bus/io.cpp
+++ b/src/nba/src/bus/io.cpp
@@ -141,8 +141,15 @@ auto Bus::Hardware::ReadByte(u32 address) ->  u8 {
     case TM3CNT_H+1: return 0;
 
     // Serial communication
+    // @todo: implement sensible read/write behaviour for the remaining registers.
     case RCNT+0: return rcnt[0];
     case RCNT+1: return rcnt[1];
+    case RCNT+2:
+    case RCNT+3: return 0;
+    case 0x04000142:
+    case 0x04000143: return 0;
+    case 0x0400015A:
+    case 0x0400015B: return 0;
 
     // Keypad
     case KEYINPUT+0: return keypad.input.ReadByte(0);
@@ -178,6 +185,9 @@ auto Bus::Hardware::ReadByte(u32 address) ->  u8 {
     case WAITCNT+2:
     case WAITCNT+3: return 0;
     case POSTFLG:   return postflg;
+    case HALTCNT:   return 0;
+    case 0x04000302: 
+    case 0x04000303: return 0;
   }
 
   return bus->ReadOpenBus(address);

--- a/src/nba/src/bus/io.cpp
+++ b/src/nba/src/bus/io.cpp
@@ -233,9 +233,6 @@ void Bus::Hardware::WriteByte(u32 address,  u8 value) {
 
   const bool apu_enable = apu_io.soundcnt.master_enable;
 
-  // @todo: solve this properly
-  ppu.Sync();
-
   switch (address) {
     // PPU
     case DISPCNT+0:  ppu_io.dispcnt.Write(0, value); break;

--- a/src/nba/src/bus/io.cpp
+++ b/src/nba/src/bus/io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/bus/io.cpp
+++ b/src/nba/src/bus/io.cpp
@@ -538,7 +538,7 @@ void Bus::Hardware::WriteByte(u32 address,  u8 value) {
       waitcnt.phi = (value >> 3) & 3;
       waitcnt.prefetch = (value >> 6) & 1;
       if(prefetch_old && !waitcnt.prefetch) {
-        prefetch_disable_bug = true;
+        prefetch_buffer_was_disabled = true;
       }
       bus->UpdateWaitStateTable();
       break;

--- a/src/nba/src/bus/io.cpp
+++ b/src/nba/src/bus/io.cpp
@@ -19,6 +19,8 @@ auto Bus::Hardware::ReadByte(u32 address) ->  u8 {
     // PPU
     case DISPCNT+0:  return ppu_io.dispcnt.Read(0);
     case DISPCNT+1:  return ppu_io.dispcnt.Read(1);
+    case GREENSWAP+0: return ppu_io.greenswap;
+    case GREENSWAP+1: return 0;
     case DISPSTAT+0: return ppu_io.dispstat.Read(0);
     case DISPSTAT+1: return ppu_io.dispstat.Read(1);
     case VCOUNT+0:   return ppu_io.vcount & 0xFF;
@@ -238,6 +240,8 @@ void Bus::Hardware::WriteByte(u32 address,  u8 value) {
     // PPU
     case DISPCNT+0:  ppu_io.dispcnt.Write(0, value); break;
     case DISPCNT+1:  ppu_io.dispcnt.Write(1, value); break;
+    case GREENSWAP+0: ppu_io.greenswap = value & 1; break;
+    case GREENSWAP+1: break;
     case DISPSTAT+0: ppu_io.dispstat.Write(0, value); break;
     case DISPSTAT+1: ppu_io.dispstat.Write(1, value); break;
     case BG0CNT+0:   ppu_io.bgcnt[0].Write(0, value); break;

--- a/src/nba/src/bus/io.hpp
+++ b/src/nba/src/bus/io.hpp
@@ -10,6 +10,7 @@
 #include <nba/integer.hpp>
 
 constexpr u32 DISPCNT = 0x04000000;
+constexpr u32 GREENSWAP = 0x04000002;
 constexpr u32 DISPSTAT = 0x04000004;
 constexpr u32 VCOUNT = 0x04000006;
 constexpr u32 BG0CNT = 0x04000008;

--- a/src/nba/src/bus/io.hpp
+++ b/src/nba/src/bus/io.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/bus/serialization.cpp
+++ b/src/nba/src/bus/serialization.cpp
@@ -45,6 +45,8 @@ void Bus::LoadState(SaveState const& state) {
   }
 
   last_access = state.bus.last_access;
+
+  parallel_internal_cpu_cycle_limit = state.bus.parallel_internal_cpu_cycle_limit;
 }
 
 void Bus::CopyState(SaveState& state) {
@@ -73,6 +75,8 @@ void Bus::CopyState(SaveState& state) {
   state.bus.prefetch.countdown = prefetch.countdown;
 
   state.bus.last_access = last_access;
+
+  state.bus.parallel_internal_cpu_cycle_limit = parallel_internal_cpu_cycle_limit;
 }
 
 } // namespace nba::core

--- a/src/nba/src/bus/serialization.cpp
+++ b/src/nba/src/bus/serialization.cpp
@@ -44,8 +44,7 @@ void Bus::LoadState(SaveState const& state) {
     prefetch.duty = wait32[int(Access::Sequential)][prefetch.last_address >> 24];
   }
 
-  dma.active = state.bus.dma.active;
-  dma.openbus = state.bus.dma.openbus;
+  last_access = state.bus.last_access;
 }
 
 void Bus::CopyState(SaveState& state) {
@@ -73,8 +72,7 @@ void Bus::CopyState(SaveState& state) {
   state.bus.prefetch.count = prefetch.count;
   state.bus.prefetch.countdown = prefetch.countdown;
 
-  state.bus.dma.active = dma.active;
-  state.bus.dma.openbus = dma.openbus;
+  state.bus.last_access = last_access;
 }
 
 } // namespace nba::core

--- a/src/nba/src/bus/serialization.cpp
+++ b/src/nba/src/bus/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/bus/serialization.cpp
+++ b/src/nba/src/bus/serialization.cpp
@@ -29,6 +29,7 @@ void Bus::LoadState(SaveState const& state) {
   hw.rcnt[0] = state.bus.io.rcnt[0];
   hw.rcnt[1] = state.bus.io.rcnt[1];
   hw.postflg = state.bus.io.postflg;
+  hw.prefetch_buffer_was_disabled = state.bus.prefetch_buffer_was_disabled;
 
   prefetch.active = state.bus.prefetch.active;
   prefetch.head_address = state.bus.prefetch.head_address;
@@ -68,6 +69,7 @@ void Bus::CopyState(SaveState& state) {
   state.bus.io.rcnt[0] = hw.rcnt[0];
   state.bus.io.rcnt[1] = hw.rcnt[1];
   state.bus.io.postflg = hw.postflg;
+  state.bus.prefetch_buffer_was_disabled = hw.prefetch_buffer_was_disabled;
 
   state.bus.prefetch.active = prefetch.active;
   state.bus.prefetch.head_address = prefetch.head_address;

--- a/src/nba/src/bus/timing.cpp
+++ b/src/nba/src/bus/timing.cpp
@@ -11,9 +11,15 @@
 namespace nba::core {
 
 void Bus::Idle() {
-  if(hw.dma.IsRunning()) hw.dma.Run();
+  if(hw.dma.IsRunning()) {
+    parallel_internal_cpu_cycle_limit = hw.dma.Run();
+  }
 
-  Step(1);
+  if(parallel_internal_cpu_cycle_limit == 0) {
+    Step(1);
+  } else {
+    parallel_internal_cpu_cycle_limit--;
+  }
 }
 
 void Bus::Prefetch(u32 address, bool code, int cycles) {

--- a/src/nba/src/bus/timing.cpp
+++ b/src/nba/src/bus/timing.cpp
@@ -11,6 +11,18 @@
 namespace nba::core {
 
 void Bus::Idle() {
+  /**
+   * The CPU can run in parallel to DMA while it executes internal cycles.
+   * It will only be stalled (for the remaining duration of DMA) once it accesses the bus again.
+   *
+   * In this emulator we unfortunately cannot cycle CPU and DMA in parallel.
+   * Instead, we track DMA duration when DMA becomes active on an internal CPU cycle.
+   * We then treat subsequent internal CPU cycles as free until the CPU accesses the bus or
+   * the total number of internal CPU cycles would exceed the DMA duration.
+   *
+   * Fortunately this should have no observable side-effects! 
+   */
+
   if(hw.dma.IsRunning()) {
     parallel_internal_cpu_cycle_limit = hw.dma.Run();
   }

--- a/src/nba/src/bus/timing.cpp
+++ b/src/nba/src/bus/timing.cpp
@@ -62,13 +62,13 @@ void Bus::Prefetch(u32 address, bool code, int cycles) {
   const int page = address >> 24;
 
   // Case #3: requested address is loaded through the Game Pak.
-  if(hw.prefetch_disable_bug) {
+  if(hw.prefetch_buffer_was_disabled) {
     // force the access to be non-sequential.
     // @todo: make this less dodgy.
          if(cycles == wait16[1][page]) cycles = wait16[0][8];
     else if(cycles == wait32[1][page]) cycles = wait32[0][8];
 
-    hw.prefetch_disable_bug = false;
+    hw.prefetch_buffer_was_disabled = false;
   }
   Step(cycles);
   if(hw.waitcnt.prefetch) {
@@ -115,7 +115,7 @@ void Bus::StopPrefetch() {
 void Bus::Step(int cycles) {
   scheduler.AddCycles(cycles);
 
-  if (prefetch.active && prefetch.countdown > 0) { // todo: perhaps remove first condition
+  if (prefetch.active && prefetch.countdown > 0) {
     prefetch.countdown -= cycles;
 
     if (prefetch.countdown <= 0) {

--- a/src/nba/src/bus/timing.cpp
+++ b/src/nba/src/bus/timing.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/bus/timing.cpp
+++ b/src/nba/src/bus/timing.cpp
@@ -115,7 +115,7 @@ void Bus::StopPrefetch() {
 void Bus::Step(int cycles) {
   scheduler.AddCycles(cycles);
 
-  if (prefetch.active && prefetch.countdown > 0) {
+  if (prefetch.active) {
     prefetch.countdown -= cycles;
 
     if (prefetch.countdown <= 0) {

--- a/src/nba/src/bus/timing.cpp
+++ b/src/nba/src/bus/timing.cpp
@@ -11,6 +11,8 @@
 namespace nba::core {
 
 void Bus::Idle() {
+  if(hw.dma.IsRunning()) hw.dma.Run();
+
   Step(1);
 }
 
@@ -85,15 +87,6 @@ void Bus::StopPrefetch() {
 }
 
 void Bus::Step(int cycles) {
-  dma.openbus = false;
-
-  if (hw.dma.IsRunning() && !dma.active) {
-    dma.active = true;
-    hw.dma.Run();
-    dma.active = false;
-    dma.openbus = true;
-  }
-
   scheduler.AddCycles(cycles);
 
   if (prefetch.active) {

--- a/src/nba/src/core.cpp
+++ b/src/nba/src/core.cpp
@@ -81,7 +81,7 @@ void Core::Run(int cycles) {
 
   while (scheduler.GetTimestampNow() < limit) {
     if (bus.hw.haltcnt == HaltControl::Halt && irq.HasServableIRQ()) {
-      bus.Idle();
+      bus.Step(1);
       bus.hw.haltcnt = HaltControl::Run;
     }
 
@@ -96,6 +96,8 @@ void Core::Run(int cycles) {
       }
       cpu.Run();
     } else {
+      if(dma.IsRunning()) dma.Run();
+
       bus.Step(scheduler.GetRemainingCycleCount());
     }
   }

--- a/src/nba/src/core.cpp
+++ b/src/nba/src/core.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/core.hpp
+++ b/src/nba/src/core.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/apu.cpp
+++ b/src/nba/src/hw/apu/apu.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/apu.cpp
+++ b/src/nba/src/hw/apu/apu.cpp
@@ -232,7 +232,10 @@ void APU::StepMixer(int cycles_late) {
     resampler->Write({ sample[0] / float(0x200), sample[1] / float(0x200) });
     buffer_mutex.unlock();
 
-    scheduler.Add(mmio.bias.GetSampleInterval() - cycles_late, this, &APU::StepMixer);
+    const int sample_interval = mmio.bias.GetSampleInterval();
+    const int cycles = sample_interval - (scheduler.GetTimestampNow() & (sample_interval - 1));
+
+    scheduler.Add(cycles - cycles_late, this, &APU::StepMixer);
   }
 }
 

--- a/src/nba/src/hw/apu/apu.hpp
+++ b/src/nba/src/hw/apu/apu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/callback.cpp
+++ b/src/nba/src/hw/apu/callback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/base_channel.hpp
+++ b/src/nba/src/hw/apu/channel/base_channel.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/envelope.hpp
+++ b/src/nba/src/hw/apu/channel/envelope.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/fifo.hpp
+++ b/src/nba/src/hw/apu/channel/fifo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/length_counter.hpp
+++ b/src/nba/src/hw/apu/channel/length_counter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/noise_channel.cpp
+++ b/src/nba/src/hw/apu/channel/noise_channel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/noise_channel.hpp
+++ b/src/nba/src/hw/apu/channel/noise_channel.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/quad_channel.cpp
+++ b/src/nba/src/hw/apu/channel/quad_channel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/quad_channel.hpp
+++ b/src/nba/src/hw/apu/channel/quad_channel.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/sweep.hpp
+++ b/src/nba/src/hw/apu/channel/sweep.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/wave_channel.cpp
+++ b/src/nba/src/hw/apu/channel/wave_channel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/channel/wave_channel.hpp
+++ b/src/nba/src/hw/apu/channel/wave_channel.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/hle/mp2k.cpp
+++ b/src/nba/src/hw/apu/hle/mp2k.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/hle/mp2k.hpp
+++ b/src/nba/src/hw/apu/hle/mp2k.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/registers.cpp
+++ b/src/nba/src/hw/apu/registers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/registers.hpp
+++ b/src/nba/src/hw/apu/registers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/apu/serialization.cpp
+++ b/src/nba/src/hw/apu/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/dma/dma.cpp
+++ b/src/nba/src/hw/dma/dma.cpp
@@ -150,14 +150,20 @@ bool DMA::HasVideoTransferDMA() {
          channels[3].time == Channel::Timing::Special;
 }
 
-void DMA::Run() {
+auto DMA::Run() -> int {
   bus.Step(1);
+
+  const auto timestamp0 = scheduler.GetTimestampNow();
 
   do {
     RunChannel();
   } while (IsRunning());
 
+  const auto timestamp1 = scheduler.GetTimestampNow();
+
   bus.Step(1);
+
+  return (int)(timestamp1 - timestamp0);
 }
 
 void DMA::RunChannel() {

--- a/src/nba/src/hw/dma/dma.cpp
+++ b/src/nba/src/hw/dma/dma.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/dma/dma.cpp
+++ b/src/nba/src/hw/dma/dma.cpp
@@ -151,13 +151,13 @@ bool DMA::HasVideoTransferDMA() {
 }
 
 void DMA::Run() {
-  bus.Idle();
+  bus.Step(1);
 
   do {
     RunChannel();
   } while (IsRunning());
 
-  bus.Idle();
+  bus.Step(1);
 }
 
 void DMA::RunChannel() {
@@ -186,15 +186,15 @@ void DMA::RunChannel() {
     auto src_addr = channel.latch.src_addr;
     auto dst_addr = channel.latch.dst_addr;
 
-    auto access_src = Bus::Access::Sequential;
-    auto access_dst = Bus::Access::Sequential;
+    auto access_src = Bus::Access::Sequential | Bus::Access::Dma;
+    auto access_dst = Bus::Access::Sequential | Bus::Access::Dma;
 
     if (!did_access_rom) {
       if (src_addr >= 0x08000000) {
-        access_src = Bus::Access::Nonsequential;
+        access_src = Bus::Access::Nonsequential | Bus::Access::Dma;
         did_access_rom = true;
       } else if (dst_addr >= 0x08000000) {
-        access_dst = Bus::Access::Nonsequential;
+        access_dst = Bus::Access::Nonsequential | Bus::Access::Dma;
         did_access_rom = true;
       }
     }
@@ -212,7 +212,7 @@ void DMA::RunChannel() {
         } else {
           value = channel.latch.bus;
         }
-        bus.Idle();
+        bus.Step(1);
       }
 
       bus.WriteHalf(dst_addr, value, access_dst);
@@ -221,7 +221,7 @@ void DMA::RunChannel() {
         channel.latch.bus = bus.ReadWord(src_addr, access_src);
         latch = channel.latch.bus;
       } else {
-        bus.Idle();
+        bus.Step(1);
       }
 
       bus.WriteWord(dst_addr, channel.latch.bus, access_dst);

--- a/src/nba/src/hw/dma/dma.hpp
+++ b/src/nba/src/hw/dma/dma.hpp
@@ -38,7 +38,7 @@ struct DMA {
   void Request(Occasion occasion);
   void StopVideoTransferDMA();
   bool HasVideoTransferDMA();
-  void Run();
+  auto Run() -> int;
   auto Read (int chan_id, int offset) -> u8;
   void Write(int chan_id, int offset, u8 value);
   bool IsRunning() { return runnable_set.any(); }

--- a/src/nba/src/hw/dma/dma.hpp
+++ b/src/nba/src/hw/dma/dma.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/dma/serialization.cpp
+++ b/src/nba/src/hw/dma/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/irq/irq.cpp
+++ b/src/nba/src/hw/irq/irq.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/irq/irq.hpp
+++ b/src/nba/src/hw/irq/irq.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/irq/serialization.cpp
+++ b/src/nba/src/hw/irq/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/keypad/keypad.cpp
+++ b/src/nba/src/hw/keypad/keypad.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/keypad/keypad.hpp
+++ b/src/nba/src/hw/keypad/keypad.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/keypad/serialization.cpp
+++ b/src/nba/src/hw/keypad/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -82,6 +82,12 @@ template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
       }
     }
 
+    if constexpr(mode == 3 || mode == 4 || mode == 5) {
+      if(mmio.enable_bg[0][2] && (cycle & 3) == 3) {
+        FetchVRAM_BG<u16>(cycle, 0);
+      }
+    }
+
     // @todo: I don't think this is always correct, at least in text-mode.
     if(++bg.cycle == k_bg_cycle_limit) {
       break;

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -102,14 +102,8 @@ template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
       }
     }
 
-    /**
-     * @todo: figure out what the correct timing for updating vertical mosaic
-     * and the internal BG X/Y registers is.
-     * It is could be possible even that the internal BG X/Y registers are 
-     * updated at the end of the scanline, since that's where they're updated,
-     * when they're written mid-frame.
-     */
-    if(cycle == 1007U) {
+    // @todo: research mosaic timing and narrow down the BG X/Y timing more precisely.
+    if(cycle == 1232U) {
       auto& mosaic = mmio.mosaic;
 
       if(mmio.vcount < 159) {

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -109,7 +109,6 @@ template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
       }
     }
 
-    // @todo: I don't think this is always correct, at least in text-mode.
     if(++bg.cycle == 1232U) {
       break;
     }

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -59,6 +59,8 @@ void PPU::DrawBackground() {
 }
 
 template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
+  const u16 latched_dispcnt_and_current_dispcnt = mmio.dispcnt_latch[0] & mmio.dispcnt.hword;
+  
   /**
    * @todo: we are losing out on some possible optimizations,
    * by implementing the various BG modes in separate methods,
@@ -73,7 +75,7 @@ template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
     if constexpr(mode <= 1) {
       const uint id = cycle & 3U; // BG0 - BG3
 
-      if((id <= 1 || mode == 0) && mmio.enable_bg[0][id] && mmio.dispcnt.enable[id]) {
+      if((id <= 1 || mode == 0) && (latched_dispcnt_and_current_dispcnt & (256U << id))) {
         RenderMode0BG(id, cycle);
       }
     }
@@ -82,25 +84,25 @@ template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
     if constexpr(mode == 1 || mode == 2) {
       const int id = ~(cycle >> 1) & 1; // 0: BG2, 1: BG3
 
-      if((id == 0 || mode == 2) && mmio.enable_bg[0][2 + id] && mmio.dispcnt.enable[2 + id]) {
+      if((id == 0 || mode == 2) && (latched_dispcnt_and_current_dispcnt & (1024U << id))) {
         RenderMode2BG(id, cycle);
       }
     }
 
     if constexpr(mode == 3) {
-      if(mmio.enable_bg[0][2] && mmio.dispcnt.enable[2]) {
+      if(latched_dispcnt_and_current_dispcnt & 1024U) {
         RenderMode3BG(cycle);
       }
     }
 
     if constexpr(mode == 4) {
-      if(mmio.enable_bg[0][2] && mmio.dispcnt.enable[2]) {
+      if(latched_dispcnt_and_current_dispcnt & 1024U) {
         RenderMode4BG(cycle);
       }
     }
 
     if constexpr(mode == 5) {
-      if(mmio.enable_bg[0][2] && mmio.dispcnt.enable[2]) {
+      if(latched_dispcnt_and_current_dispcnt & 1024U) {
         RenderMode5BG(cycle);
       }
     }

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -73,7 +73,7 @@ template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
     if constexpr(mode <= 1) {
       const uint id = cycle & 3U; // BG0 - BG3
 
-      if((id <= 1 || mode == 0) && mmio.enable_bg[0][id]) {
+      if((id <= 1 || mode == 0) && mmio.enable_bg[0][id] && mmio.dispcnt.enable[id]) {
         RenderMode0BG(id, cycle);
       }
     }
@@ -82,25 +82,25 @@ template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
     if constexpr(mode == 1 || mode == 2) {
       const int id = ~(cycle >> 1) & 1; // 0: BG2, 1: BG3
 
-      if((id == 0 || mode == 2) && mmio.enable_bg[0][2 + id]) {
+      if((id == 0 || mode == 2) && mmio.enable_bg[0][2 + id] && mmio.dispcnt.enable[2 + id]) {
         RenderMode2BG(id, cycle);
       }
     }
 
     if constexpr(mode == 3) {
-      if(mmio.enable_bg[0][2]) {
+      if(mmio.enable_bg[0][2] && mmio.dispcnt.enable[2]) {
         RenderMode3BG(cycle);
       }
     }
 
     if constexpr(mode == 4) {
-      if(mmio.enable_bg[0][2]) {
+      if(mmio.enable_bg[0][2] && mmio.dispcnt.enable[2]) {
         RenderMode4BG(cycle);
       }
     }
 
     if constexpr(mode == 5) {
-      if(mmio.enable_bg[0][2]) {
+      if(mmio.enable_bg[0][2] && mmio.dispcnt.enable[2]) {
         RenderMode5BG(cycle);
       }
     }

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -24,6 +24,13 @@ void PPU::InitBackground() {
     bg.affine[id].x = mmio.bgx[id]._current;
     bg.affine[id].y = mmio.bgy[id]._current;
   }
+
+  /**
+   * We are latching this, because the currently the counter
+   * in incremented in H-blank, which means that it might happen 
+   * before BG rendering is done (because there is no sync point at H-blank).
+   */
+  bg.mosaic_counter = mmio.mosaic.bg._counter_y;
 }
 
 void PPU::DrawBackground() {
@@ -34,8 +41,6 @@ void PPU::DrawBackground() {
   if(cycles == 0 || bg.cycle >= k_bg_cycle_limit) {
     return;
   }
-
-  // fmt::print("PPU: draw background @ VCOUNT={} delta={}\n", mmio.vcount, cycles);
 
   const int mode = mmio.dispcnt.mode;
 

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -20,9 +20,24 @@ void PPU::InitBackground() {
     text.fetches = 0;
   }
 
+  const bool first_scanline = mmio.vcount == 0;
+
   for(int id = 0; id < 2; id++) {
-    bg.affine[id].x = mmio.bgx[id]._current;
-    bg.affine[id].y = mmio.bgy[id]._current;
+    auto& bgx = mmio.bgx[id];
+    auto& bgy = mmio.bgy[id];
+
+    // @todo: should BGY be latched when BGX was written and vice versa?
+    if(bgx.written || first_scanline) {
+      bgx._current = bgx.initial;
+      bgx.written = false;
+    }
+    if(bgy.written || first_scanline) {
+      bgy._current = bgy.initial;
+      bgy.written = false;
+    }
+
+    bg.affine[id].x = bgx._current;
+    bg.affine[id].y = bgy._current;
   }
 }
 

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -82,9 +82,21 @@ template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
       }
     }
 
-    if constexpr(mode == 3 || mode == 4 || mode == 5) {
-      if(mmio.enable_bg[0][2] && (cycle & 3) == 3) {
-        FetchVRAM_BG<u16>(cycle, 0);
+    if constexpr(mode == 3) {
+      if(mmio.enable_bg[0][2]) {
+        RenderMode3BG(cycle);
+      }
+    }
+
+    if constexpr(mode == 4) {
+      if(mmio.enable_bg[0][2]) {
+        RenderMode4BG(cycle);
+      }
+    }
+
+    if constexpr(mode == 5) {
+      if(mmio.enable_bg[0][2]) {
+        RenderMode5BG(cycle);
       }
     }
 

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -30,7 +30,7 @@ void PPU::InitBackground() {
    * in incremented in H-blank, which means that it might happen 
    * before BG rendering is done (because there is no sync point at H-blank).
    */
-  bg.mosaic_counter = mmio.mosaic.bg._counter_y;
+  bg.mosaic_y = mmio.mosaic.bg._counter_y;
 }
 
 void PPU::DrawBackground() {

--- a/src/nba/src/hw/ppu/background.cpp
+++ b/src/nba/src/hw/ppu/background.cpp
@@ -17,7 +17,7 @@ void PPU::InitBackground() {
   bg.cycle = 0U;
 
   for(auto& text : bg.text) {
-    text.fetching = false;
+    text.fetches = 0;
   }
 
   for(int id = 0; id < 2; id++) {
@@ -38,7 +38,7 @@ void PPU::DrawBackground() {
   
   const int cycles = (int)(timestamp_now - bg.timestamp_last_sync);
 
-  if(cycles == 0 || bg.cycle >= k_bg_cycle_limit) {
+  if(cycles == 0 || bg.cycle >= 1232U) {
     return;
   }
 
@@ -80,35 +80,37 @@ template<int mode> void PPU::DrawBackgroundImpl(int cycles) {
       }
     }
 
-    // affine backgrounds
-    if constexpr(mode == 1 || mode == 2) {
-      const int id = ~(cycle >> 1) & 1; // 0: BG2, 1: BG3
+    if(cycle < 1007U) {
+      // affine backgrounds
+      if constexpr(mode == 1 || mode == 2) {
+        const int id = ~(cycle >> 1) & 1; // 0: BG2, 1: BG3
 
-      if((id == 0 || mode == 2) && (latched_dispcnt_and_current_dispcnt & (1024U << id))) {
-        RenderMode2BG(id, cycle);
+        if((id == 0 || mode == 2) && (latched_dispcnt_and_current_dispcnt & (1024U << id))) {
+          RenderMode2BG(id, cycle);
+        }
       }
-    }
 
-    if constexpr(mode == 3) {
-      if(latched_dispcnt_and_current_dispcnt & 1024U) {
-        RenderMode3BG(cycle);
+      if constexpr(mode == 3) {
+        if(latched_dispcnt_and_current_dispcnt & 1024U) {
+          RenderMode3BG(cycle);
+        }
       }
-    }
 
-    if constexpr(mode == 4) {
-      if(latched_dispcnt_and_current_dispcnt & 1024U) {
-        RenderMode4BG(cycle);
+      if constexpr(mode == 4) {
+        if(latched_dispcnt_and_current_dispcnt & 1024U) {
+          RenderMode4BG(cycle);
+        }
       }
-    }
 
-    if constexpr(mode == 5) {
-      if(latched_dispcnt_and_current_dispcnt & 1024U) {
-        RenderMode5BG(cycle);
+      if constexpr(mode == 5) {
+        if(latched_dispcnt_and_current_dispcnt & 1024U) {
+          RenderMode5BG(cycle);
+        }
       }
     }
 
     // @todo: I don't think this is always correct, at least in text-mode.
-    if(++bg.cycle == k_bg_cycle_limit) {
+    if(++bg.cycle == 1232U) {
       break;
     }
   }

--- a/src/nba/src/hw/ppu/background.inl
+++ b/src/nba/src/hw/ppu/background.inl
@@ -70,7 +70,7 @@ void ALWAYS_INLINE RenderMode0BG(uint id, uint cycle) {
     /*const*/ uint line = mmio.vcount + mmio.bgvofs[id];
 
     if(bgcnt.mosaic_enable) {
-      line -= (uint)bg.mosaic_counter;
+      line -= (uint)bg.mosaic_y;
     }
 
     const uint grid_x = bghofs_div_8 + (step >> 3) - 1U;

--- a/src/nba/src/hw/ppu/background.inl
+++ b/src/nba/src/hw/ppu/background.inl
@@ -70,7 +70,7 @@ void ALWAYS_INLINE RenderMode0BG(uint id, uint cycle) {
     /*const*/ uint line = mmio.vcount + mmio.bgvofs[id];
 
     if(bgcnt.mosaic_enable) {
-      line -= (uint)mmio.mosaic.bg._counter_y;
+      line -= (uint)bg.mosaic_counter;
     }
 
     const uint grid_x = bghofs_div_8 + (step >> 3) - 1U;

--- a/src/nba/src/hw/ppu/background.inl
+++ b/src/nba/src/hw/ppu/background.inl
@@ -167,3 +167,81 @@ void ALWAYS_INLINE RenderMode2BG(uint id, uint cycle) {
     }
   }
 }
+
+void ALWAYS_INLINE RenderMode3BG(uint cycle) {
+  if(cycle < 32U || (cycle & 3U) != 3U) {
+    return;
+  }
+
+  const uint screen_x = (cycle - 32U) >> 2;
+
+  const s32 x = bg.affine[0].x >> 8;
+  const s32 y = bg.affine[0].y >> 8;
+
+  u32 color = 0U;
+
+  if(x >= 0 && x < 240 && y >= 0 && y < 160) {
+    const u32 address = ((u32)y * 240U + (u32)x) * 2U;
+
+    color = FetchVRAM_BG<u16>(cycle, address) | 0x8000'0000;
+  }
+
+  if(screen_x < 240U) { // @todo: make the buffer big enough that an overrun cannot happen.
+    bg.buffer[screen_x][2] = color | 0x8000'0000;
+  }
+
+  bg.affine[0].x += mmio.bgpa[0];
+  bg.affine[0].y += mmio.bgpc[0];
+}
+
+void ALWAYS_INLINE RenderMode4BG(uint cycle) {
+  if(cycle < 32U || (cycle & 3U) != 3U) {
+    return;
+  }
+
+  const uint screen_x = (cycle - 32U) >> 2;
+
+  const s32 x = bg.affine[0].x >> 8;
+  const s32 y = bg.affine[0].y >> 8;
+
+  uint index = 0U;
+
+  if(x >= 0 && x < 240 && y >= 0 && y < 160) {
+    const u32 address = mmio.dispcnt.frame * 0xA000U + (u32)y * 240U + (u32)x;
+
+    index = FetchVRAM_BG<u8>(cycle, address);
+  }
+
+  if(screen_x < 240U) { // @todo: make the buffer big enough that an overrun cannot happen.
+    bg.buffer[screen_x][2] = index;
+  }
+
+  bg.affine[0].x += mmio.bgpa[0];
+  bg.affine[0].y += mmio.bgpc[0];
+}
+
+void ALWAYS_INLINE RenderMode5BG(uint cycle) {
+  if(cycle < 32U || (cycle & 3U) != 3U) {
+    return;
+  }
+
+  const uint screen_x = (cycle - 32U) >> 2;
+
+  const s32 x = bg.affine[0].x >> 8;
+  const s32 y = bg.affine[0].y >> 8;
+
+  u32 color = 0U;
+
+  if(x >= 0 && x < 160 && y >= 0 && y < 128) {
+    const u32 address = mmio.dispcnt.frame * 0xA000U + ((u32)y * 160U + (u32)x) * 2U;
+
+    color = FetchVRAM_BG<u16>(cycle, address) | 0x8000'0000;
+  }
+
+  if(screen_x < 240U) { // @todo: make the buffer big enough that an overrun cannot happen.
+    bg.buffer[screen_x][2] = color;
+  }
+
+  bg.affine[0].x += mmio.bgpa[0];
+  bg.affine[0].y += mmio.bgpc[0];
+}

--- a/src/nba/src/hw/ppu/background.inl
+++ b/src/nba/src/hw/ppu/background.inl
@@ -197,7 +197,7 @@ void ALWAYS_INLINE RenderMode3BG(uint cycle) {
   }
 
   if(screen_x < 240U) {
-    bg.buffer[screen_x][2] = color | 0x8000'0000;
+    bg.buffer[screen_x][2] = color;
   }
 
   bg.affine[0].x += mmio.bgpa[0];

--- a/src/nba/src/hw/ppu/background.inl
+++ b/src/nba/src/hw/ppu/background.inl
@@ -186,7 +186,7 @@ void ALWAYS_INLINE RenderMode3BG(uint cycle) {
     color = FetchVRAM_BG<u16>(cycle, address) | 0x8000'0000;
   }
 
-  if(screen_x < 240U) { // @todo: make the buffer big enough that an overrun cannot happen.
+  if(screen_x < 240U) {
     bg.buffer[screen_x][2] = color | 0x8000'0000;
   }
 
@@ -212,7 +212,7 @@ void ALWAYS_INLINE RenderMode4BG(uint cycle) {
     index = FetchVRAM_BG<u8>(cycle, address);
   }
 
-  if(screen_x < 240U) { // @todo: make the buffer big enough that an overrun cannot happen.
+  if(screen_x < 240U) {
     bg.buffer[screen_x][2] = index;
   }
 
@@ -238,7 +238,7 @@ void ALWAYS_INLINE RenderMode5BG(uint cycle) {
     color = FetchVRAM_BG<u16>(cycle, address) | 0x8000'0000;
   }
 
-  if(screen_x < 240U) { // @todo: make the buffer big enough that an overrun cannot happen.
+  if(screen_x < 240U) {
     bg.buffer[screen_x][2] = color;
   }
 

--- a/src/nba/src/hw/ppu/background.inl
+++ b/src/nba/src/hw/ppu/background.inl
@@ -70,7 +70,7 @@ void ALWAYS_INLINE RenderMode0BG(uint id, uint cycle) {
     uint line = mmio.vcount + mmio.bgvofs[id];
 
     if(bgcnt.mosaic_enable) {
-      line -= (uint)bg.mosaic_y;
+      line -= (uint)mmio.mosaic.bg._counter_y;
     }
 
     const uint grid_x = bghofs_div_8 + (step >> 3) - 1U;

--- a/src/nba/src/hw/ppu/merge.cpp
+++ b/src/nba/src/hw/ppu/merge.cpp
@@ -197,7 +197,27 @@ void PPU::DrawMergeImpl(int cycles) {
         }
       }
 
-      output[frame][mmio.vcount * 240 + x] = RGB555(colors[0]);
+      if(x & 1) {
+        u16 color_l = merge.color_l;
+        u16 color_r = colors[0];
+
+        if(mmio.greenswap & 1) {
+          const u16 mask = 31U << 5;
+
+          u16 g_l = color_l & mask;
+          u16 g_r = color_r & mask;
+
+          color_l = (color_l & ~mask) | g_r;
+          color_r = (color_r & ~mask) | g_l;
+        }
+
+        u32* out = &output[frame][mmio.vcount * 240 + (x & ~1)];
+
+        out[0] = RGB555(color_l);
+        out[1] = RGB555(color_r);
+      } else {
+        merge.color_l = colors[0];
+      }
 
       if(++merge.mosaic_x[0] == (uint)mmio.mosaic.bg.size_x) {
         merge.mosaic_x[0] = 0U;

--- a/src/nba/src/hw/ppu/merge.cpp
+++ b/src/nba/src/hw/ppu/merge.cpp
@@ -214,22 +214,21 @@ void PPU::DrawMergeImpl(int cycles) {
   }
 }
 
-// @todo: respect the 6-th green channel bit during blending.
-
 auto PPU::Blend(u16 color_a, u16 color_b, int eva, int evb) -> u16 {
-  const int r_a = (color_a >>  0) & 31;
-  const int g_a = (color_a >>  5) & 31;
-  const int b_a = (color_a >> 10) & 31;
+  const int r_a =  (color_a >>  0) & 31;
+  const int g_a = ((color_a >>  4) & 62) | (color_a >> 15 << 5);
+  const int b_a =  (color_a >> 10) & 31;
 
-  const int r_b = (color_b >>  0) & 31;
-  const int g_b = (color_b >>  5) & 31;
-  const int b_b = (color_b >> 10) & 31;
+  const int r_b =  (color_b >>  0) & 31;
+  const int g_b = ((color_b >>  4) & 62) | (color_b >> 15 << 5);
+  const int b_b =  (color_b >> 10) & 31;
 
   eva = std::min<int>(16, eva);
   evb = std::min<int>(16, evb);
 
+  // @todo: round to nearest?
   const int r = std::min<u8>((r_a * eva + r_b * evb) >> 4, 31);
-  const int g = std::min<u8>((g_a * eva + g_b * evb) >> 4, 31);
+  const int g = std::min<u8>((g_a * eva + g_b * evb) >> 4, 63) >> 1;
   const int b = std::min<u8>((b_a * eva + b_b * evb) >> 4, 31);
 
   return (u16)((b << 10) | (g << 5) | r);
@@ -238,13 +237,15 @@ auto PPU::Blend(u16 color_a, u16 color_b, int eva, int evb) -> u16 {
 auto PPU::Brighten(u16 color, int evy) -> u16 {
   evy = std::min<int>(16, evy);
 
-  int r = (color >>  0) & 31;
-  int g = (color >>  5) & 31;
-  int b = (color >> 10) & 31;
+  int r =  (color >>  0) & 31;
+  int g = ((color >>  4) & 62) | (color >> 15 << 5);
+  int b =  (color >> 10) & 31;
 
   r += ((31 - r) * evy) >> 4;
-  g += ((31 - g) * evy) >> 4;
+  g += ((63 - g) * evy) >> 4;
   b += ((31 - b) * evy) >> 4;
+
+  g >>= 1;
   
   return (u16)((b << 10) | (g << 5) | r);
 }
@@ -252,13 +253,15 @@ auto PPU::Brighten(u16 color, int evy) -> u16 {
 auto PPU::Darken(u16 color, int evy) -> u16 {
   evy = std::min<int>(16, evy);
 
-  int r = (color >>  0) & 31;
-  int g = (color >>  5) & 31;
-  int b = (color >> 10) & 31;
+  int r =  (color >>  0) & 31;
+  int g = ((color >>  4) & 62) | (color >> 15 << 5);
+  int b =  (color >> 10) & 31;
 
   r -= (r * evy) >> 4;
   g -= (g * evy) >> 4;
   b -= (b * evy) >> 4;
+
+  g >>= 1;
 
   return (u16)((b << 10) | (g << 5) | r);
 }

--- a/src/nba/src/hw/ppu/merge.cpp
+++ b/src/nba/src/hw/ppu/merge.cpp
@@ -76,10 +76,11 @@ void PPU::DrawMergeImpl(int cycles) {
     }
   }
 
-  // @todo: should the OBJWIN be disabled if sprites are disabled?
+  const bool enable_obj = latched_dispcnt_and_current_dispcnt & (256U << LAYER_OBJ);
+
   const bool enable_win0 = mmio.dispcnt.enable[ENABLE_WIN0];
   const bool enable_win1 = mmio.dispcnt.enable[ENABLE_WIN1];
-  const bool enable_objwin = mmio.dispcnt.enable[ENABLE_OBJWIN];
+  const bool enable_objwin = mmio.dispcnt.enable[ENABLE_OBJWIN] && enable_obj;
 
   const bool have_windows = enable_win0 || enable_win1 || enable_objwin;
 
@@ -150,7 +151,7 @@ void PPU::DrawMergeImpl(int cycles) {
 
         merge.force_alpha_blend = false;
 
-        if(mmio.dispcnt.enable[LAYER_OBJ] && (!have_windows || win_layer_enable[LAYER_OBJ])) {
+        if(enable_obj && (!have_windows || win_layer_enable[LAYER_OBJ])) {
           auto pixel = sprite.buffer_rd[x];
 
           if(pixel.mosaic) pixel = sprite.buffer_rd[x - merge.mosaic_x[1]];

--- a/src/nba/src/hw/ppu/merge.cpp
+++ b/src/nba/src/hw/ppu/merge.cpp
@@ -35,7 +35,7 @@ void PPU::DrawMerge() {
   
   const int cycles = (int)(timestamp_now - merge.timestamp_last_sync);
 
-  if(cycles == 0 || merge.cycle >= k_bg_cycle_limit) {
+  if(cycles == 0 || merge.cycle >= 1006U) {
     return;
   }
 
@@ -253,7 +253,7 @@ void PPU::DrawMergeImpl(int cycles) {
       }
     }
 
-    if(++merge.cycle == k_bg_cycle_limit) {
+    if(++merge.cycle == 1006U) {
       break;
     }
   }

--- a/src/nba/src/hw/ppu/merge.cpp
+++ b/src/nba/src/hw/ppu/merge.cpp
@@ -251,11 +251,11 @@ void PPU::DrawMergeImpl(int cycles) {
 
 auto PPU::Blend(u16 color_a, u16 color_b, int eva, int evb) -> u16 {
   const int r_a =  (color_a >>  0) & 31;
-  const int g_a = ((color_a >>  4) & 62) | (color_a >> 15 << 5);
+  const int g_a = ((color_a >>  4) & 62) | (color_a >> 15);
   const int b_a =  (color_a >> 10) & 31;
 
   const int r_b =  (color_b >>  0) & 31;
-  const int g_b = ((color_b >>  4) & 62) | (color_b >> 15 << 5);
+  const int g_b = ((color_b >>  4) & 62) | (color_b >> 15);
   const int b_b =  (color_b >> 10) & 31;
 
   eva = std::min<int>(16, eva);
@@ -272,7 +272,7 @@ auto PPU::Brighten(u16 color, int evy) -> u16 {
   evy = std::min<int>(16, evy);
 
   int r =  (color >>  0) & 31;
-  int g = ((color >>  4) & 62) | (color >> 15 << 5);
+  int g = ((color >>  4) & 62) | (color >> 15);
   int b =  (color >> 10) & 31;
 
   r += ((31 - r) * evy + 8) >> 4;
@@ -288,7 +288,7 @@ auto PPU::Darken(u16 color, int evy) -> u16 {
   evy = std::min<int>(16, evy);
 
   int r =  (color >>  0) & 31;
-  int g = ((color >>  4) & 62) | (color >> 15 << 5);
+  int g = ((color >>  4) & 62) | (color >> 15);
   int b =  (color >> 10) & 31;
 
   r -= (r * evy + 7) >> 4;

--- a/src/nba/src/hw/ppu/merge.cpp
+++ b/src/nba/src/hw/ppu/merge.cpp
@@ -61,15 +61,15 @@ void PPU::DrawMergeImpl(int cycles) {
   const int min_bg = k_min_max_bg[mode][0];
   const int max_bg = k_min_max_bg[mode][1];
 
+  const u16 latched_dispcnt_and_current_dispcnt = mmio.dispcnt_latch[0] & mmio.dispcnt.hword;
+
   // Enabled BGs sorted from highest to lowest priority.
   int bg_list[4];
   int bg_count = 0;
 
   for(int priority = 0; priority <= 3; priority++) {
     for(int id = min_bg; id <= max_bg; id++) {
-      if(mmio.bgcnt[id].priority == priority &&
-         mmio.enable_bg[0][id] &&
-         mmio.dispcnt.enable[id]) {
+      if(mmio.bgcnt[id].priority == priority && (latched_dispcnt_and_current_dispcnt & (256U << id))) {
         bg_list[bg_count++] = id;
       }
     }

--- a/src/nba/src/hw/ppu/merge.cpp
+++ b/src/nba/src/hw/ppu/merge.cpp
@@ -101,7 +101,7 @@ void PPU::DrawMergeImpl(int cycles) {
         }
       }
 
-      output[frame][mmio.vcount * 240 + x] = RGB555(read<u16>(pram, final_color << 1));
+      output[frame][mmio.vcount * 240 + x] = RGB555(FetchPRAM<u16>(merge.cycle, final_color << 1));
     }
 
     if(++merge.cycle == k_bg_cycle_limit) {

--- a/src/nba/src/hw/ppu/merge.cpp
+++ b/src/nba/src/hw/ppu/merge.cpp
@@ -226,10 +226,9 @@ auto PPU::Blend(u16 color_a, u16 color_b, int eva, int evb) -> u16 {
   eva = std::min<int>(16, eva);
   evb = std::min<int>(16, evb);
 
-  // @todo: round to nearest?
-  const int r = std::min<u8>((r_a * eva + r_b * evb) >> 4, 31);
-  const int g = std::min<u8>((g_a * eva + g_b * evb) >> 4, 63) >> 1;
-  const int b = std::min<u8>((b_a * eva + b_b * evb) >> 4, 31);
+  const int r = std::min<u8>((r_a * eva + r_b * evb + 8) >> 4, 31);
+  const int g = std::min<u8>((g_a * eva + g_b * evb + 8) >> 4, 63) >> 1;
+  const int b = std::min<u8>((b_a * eva + b_b * evb + 8) >> 4, 31);
 
   return (u16)((b << 10) | (g << 5) | r);
 }
@@ -241,9 +240,9 @@ auto PPU::Brighten(u16 color, int evy) -> u16 {
   int g = ((color >>  4) & 62) | (color >> 15 << 5);
   int b =  (color >> 10) & 31;
 
-  r += ((31 - r) * evy) >> 4;
-  g += ((63 - g) * evy) >> 4;
-  b += ((31 - b) * evy) >> 4;
+  r += ((31 - r) * evy + 8) >> 4;
+  g += ((63 - g) * evy + 8) >> 4;
+  b += ((31 - b) * evy + 8) >> 4;
 
   g >>= 1;
   
@@ -257,9 +256,9 @@ auto PPU::Darken(u16 color, int evy) -> u16 {
   int g = ((color >>  4) & 62) | (color >> 15 << 5);
   int b =  (color >> 10) & 31;
 
-  r -= (r * evy) >> 4;
-  g -= (g * evy) >> 4;
-  b -= (b * evy) >> 4;
+  r -= (r * evy + 7) >> 4;
+  g -= (g * evy + 7) >> 4;
+  b -= (b * evy + 7) >> 4;
 
   g >>= 1;
 

--- a/src/nba/src/hw/ppu/ppu.cpp
+++ b/src/nba/src/hw/ppu/ppu.cpp
@@ -33,6 +33,8 @@ void PPU::Reset() {
   mmio.dispcnt.Reset();
   mmio.dispstat.Reset();
 
+  mmio.greenswap = 0U;
+
   for (int i = 0; i < 4; i++) {
     mmio.enable_bg[0][i] = false;
     mmio.enable_bg[1][i] = false;

--- a/src/nba/src/hw/ppu/ppu.cpp
+++ b/src/nba/src/hw/ppu/ppu.cpp
@@ -162,7 +162,10 @@ void PPU::OnScanlineComplete(int cycles_late) {
 
   mmio.dispstat.hblank_flag = 1;
 
-  dma.Request(DMA::Occasion::HBlank);
+  // TODO: fix these timings properly eventually.
+  scheduler.Add(1, [this](int) {
+    dma.Request(DMA::Occasion::HBlank);
+  });
   
   // Advance vertical background mosaic counter
   if (++mosaic.bg._counter_y == mosaic.bg.size_y) {
@@ -223,7 +226,9 @@ void PPU::OnHblankComplete(int cycles_late) {
   DrawWindow();
   DrawMerge();
 
-  scheduler.Add(38, [this](int){LatchEnabledBGs();});
+  scheduler.Add(40, [this](int) {
+    LatchEnabledBGs();
+  });
 
   dispstat.hblank_flag = 0;
   vcount++;
@@ -304,8 +309,10 @@ void PPU::OnVblankHblankComplete(int cycles_late) {
     dma3_video_transfer_running = dma.HasVideoTransferDMA();
   }
 
-  if(vcount >= 224) { // @todo: verify
-    scheduler.Add(38, [this](int){LatchEnabledBGs();});
+  if(vcount >= 224) {
+    scheduler.Add(40, [this](int) {
+      LatchEnabledBGs();
+    });
   }
 
   if (vcount == 227) {

--- a/src/nba/src/hw/ppu/ppu.cpp
+++ b/src/nba/src/hw/ppu/ppu.cpp
@@ -105,24 +105,6 @@ void PPU::LatchDISPCNT() {
   mmio.dispcnt_latch[2] = mmio.dispcnt.hword;
 }
 
-void PPU::LatchBGXYWrites() {
-  // TODO: should BGY be latched when BGX was written and vice versa?
-  for (int i = 0; i < 2; i++) {
-    auto& bgx = mmio.bgx[i];
-    auto& bgy = mmio.bgy[i];
-
-    if (bgx.written) {
-      bgx._current = bgx.initial;
-      bgx.written = false;
-    }
-
-    if (bgy.written) {
-      bgy._current = bgy.initial;
-      bgy.written = false;
-    }
-  }
-}
-
 void PPU::CheckVerticalCounterIRQ() {
   auto& dispstat = mmio.dispstat;
   auto vcount_flag_new = dispstat.vcount_setting == mmio.vcount;
@@ -187,7 +169,6 @@ void PPU::OnHblankComplete(int cycles_late) {
   vcount++;
 
   CheckVerticalCounterIRQ();
-  LatchBGXYWrites();
   UpdateVideoTransferDMA();
 
   if (vcount == 160) {
@@ -274,7 +255,6 @@ void PPU::OnVblankHblankComplete(int cycles_late) {
     }
   }
 
-  LatchBGXYWrites();
   CheckVerticalCounterIRQ();
   // ScheduleSubmitScanline();
   UpdateVideoTransferDMA();

--- a/src/nba/src/hw/ppu/ppu.cpp
+++ b/src/nba/src/hw/ppu/ppu.cpp
@@ -74,8 +74,10 @@ void PPU::Reset() {
   // from a separate event loop.
   scheduler.Add(266, this, &PPU::StupidSpriteEventHandler);
 
+  // @todo: initialize window with the appropriate timing.
   bg = {};
   sprite = {};
+  window = {};
   merge = {};
 
   frame = 0;
@@ -219,6 +221,7 @@ void PPU::OnHblankComplete(int cycles_late) {
   auto& mosaic = mmio.mosaic;
 
   DrawBackground();
+  DrawWindow();
   DrawMerge();
 
   dispstat.hblank_flag = 0;
@@ -255,6 +258,8 @@ void PPU::OnHblankComplete(int cycles_late) {
     scheduler.Add(1006 - cycles_late, this, &PPU::OnScanlineComplete);
     // ScheduleSubmitScanline();
   }
+
+  InitWindow();
 }
 
 void PPU::OnVblankScanlineComplete(int cycles_late) {
@@ -292,6 +297,8 @@ void PPU::OnVblankHblankComplete(int cycles_late) {
   auto& vcount = mmio.vcount;
   auto& dispstat = mmio.dispstat;
 
+  DrawWindow();
+
   dispstat.hblank_flag = 0;
 
   if (vcount == 162) {
@@ -324,6 +331,8 @@ void PPU::OnVblankHblankComplete(int cycles_late) {
   CheckVerticalCounterIRQ();
   // ScheduleSubmitScanline();
   UpdateVideoTransferDMA();
+
+  InitWindow();
 }
 
 } // namespace nba::core

--- a/src/nba/src/hw/ppu/ppu.cpp
+++ b/src/nba/src/hw/ppu/ppu.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -356,6 +356,7 @@ private:
     u64 timestamp_last_sync = 0;
     u64 timestamp_pram_access = 0;
     uint cycle;
+    uint mosaic_x[2];
   } merge;
 
   void InitMerge();

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -324,6 +324,8 @@ private:
     Pixel buffer[2][240];
     Pixel* buffer_rd;
     Pixel* buffer_wr;
+
+    uint latch_cycle_limit;
   } sprite;
 
   void InitSprite();

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -267,27 +267,25 @@ private:
     struct {
       uint index;
       int  step;
-      uint address;
       int  wait;
+      int  pending_wait;
       bool delay_wait;
+      int  initial_local_x;
+      int  initial_local_y;
+      uint matrix_address;
     } oam_fetch;
 
     bool drawing;
 
     struct {
-      s32 x;
-      s32 y;
       int width;
       int height;
-      int half_width;
-      int half_height;
       int mode;
       bool mosaic;
       bool affine;
 
       int draw_x;
       int remaining_pixels;
-      int local_y;
 
       s16 matrix[4];
 

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -271,6 +271,7 @@ private:
     u64 timestamp_oam_access = ~0ULL;
     uint cycle;
     uint vcount;
+    int mosaic_counter;
 
     struct {
       uint index;

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -359,6 +359,9 @@ private:
     u64 timestamp_pram_access = 0;
     uint cycle;
     uint mosaic_x[2];
+    int layers[2];
+    bool force_alpha_blend;
+    u32 colors[2];
     u16 color_l;
   } merge;
 

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -176,7 +176,7 @@ struct PPU {
     int evb;
     int evy;
 
-    bool enable_bg[2][4];
+    bool enable_bg[3][4];
   } mmio;
 
 private:

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -258,8 +258,6 @@ private:
     } affine[2];
 
     u32 buffer[240][4];
-
-    int mosaic_y;
   } bg;
 
   void InitBackground();
@@ -273,7 +271,6 @@ private:
     u64 timestamp_oam_access = ~0ULL;
     uint cycle;
     uint vcount;
-    int mosaic_y;
 
     struct {
       uint index;

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -151,6 +151,8 @@ struct PPU {
     DisplayControl dispcnt;
     DisplayStatus dispstat;
 
+    u16 greenswap;
+
     u8 vcount;
 
     BackgroundControl bgcnt[4] { 0, 1, 2, 3 };
@@ -357,6 +359,7 @@ private:
     u64 timestamp_pram_access = 0;
     uint cycle;
     uint mosaic_x[2];
+    u16 color_l;
   } merge;
 
   void InitMerge();

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -258,6 +258,8 @@ private:
     } affine[2];
 
     u32 buffer[240][4];
+
+    int mosaic_counter;
   } bg;
 
   void InitBackground();

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -253,7 +253,7 @@ private:
       u16 tile_address;
     } affine[2];
 
-    u8 buffer[240][4];
+    u32 buffer[240][4];
   } bg;
 
   void InitBackground();

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -336,20 +336,26 @@ private:
   void DrawMergeImpl(int cycles);
 
   template<typename T>
-  auto ALWAYS_INLINE FetchOAM(uint cycle, uint address) -> T {
-    sprite.timestamp_oam_access = sprite.timestamp_init + cycle;
-    return read<T>(oam, address);
+  auto ALWAYS_INLINE FetchVRAM_BG(uint cycle, uint address) -> T {
+    bg.timestamp_vram_access = bg.timestamp_init + cycle;
+    return read<T>(vram, address);
   }
 
   template<typename T>
   auto ALWAYS_INLINE FetchVRAM_OBJ(uint cycle, uint address) -> T {
-    sprite.timestamp_vram_access = sprite.timestamp_init + sprite.cycle;
+    sprite.timestamp_vram_access = sprite.timestamp_init + cycle;
 
     // @todo: verify this edge-case against hardware.
     if(address < GetSpriteVRAMBoundary()) {
       return 0U;
     }
     return read<T>(vram, address);
+  }
+
+  template<typename T>
+  auto ALWAYS_INLINE FetchOAM(uint cycle, uint address) -> T {
+    sprite.timestamp_oam_access = sprite.timestamp_init + cycle;
+    return read<T>(oam, address);
   }
 
   u8 pram[0x00400];

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -138,8 +138,12 @@ struct PPU {
   }
 
   void Sync() {
+    // @todo: only update the window when it is necessary or else
+    // we will have a major performance caveat due to the window being updated 
+    // during V-blank and games typically updating graphics during V-blank.
     DrawBackground();
     DrawSprite();
+    DrawWindow();
     DrawMerge();
   }
 
@@ -328,6 +332,19 @@ private:
   void DrawSpriteFetchOAM(uint cycle);
   void DrawSpriteFetchVRAM(uint cycle);
   void StupidSpriteEventHandler(int cycles);
+
+  struct Window {
+    u64 timestamp_last_sync;
+    uint cycle;
+
+    bool v_flag[2] {false, false};
+    bool h_flag[2] {false, false};
+
+    bool buffer[240][2];
+  } window;
+
+  void InitWindow();
+  void DrawWindow();
 
   struct Merge {
     u64 timestamp_init = 0;

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -339,6 +339,10 @@ private:
   void InitMerge();
   void DrawMerge();
   void DrawMergeImpl(int cycles);
+  
+  static auto Blend(u16 color_a, u16 color_b, int eva, int evb) -> u16;
+  static auto Brighten(u16 color, int evy) -> u16;
+  static auto Darken(u16 color, int evy) -> u16;
 
   template<typename T>
   auto ALWAYS_INLINE FetchPRAM(uint cycle, uint address) -> T {

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -218,7 +218,6 @@ private:
   };
 
   void LatchDISPCNT();
-  void LatchBGXYWrites();
   void CheckVerticalCounterIRQ();
   void UpdateVideoTransferDMA();
 

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -182,8 +182,6 @@ struct PPU {
   } mmio;
 
 private:
-  static constexpr uint k_bg_cycle_limit = 1006;
-
   friend struct DisplayStatus;
 
   enum ObjAttribute {
@@ -238,7 +236,7 @@ private:
     uint cycle;
 
     struct Text {
-      bool fetching;
+      int fetches;
 
       struct Tile {
         u32 address;

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -178,7 +178,7 @@ struct PPU {
     int evb;
     int evy;
 
-    bool enable_bg[3][4];
+    u16 dispcnt_latch[3];
   } mmio;
 
 private:
@@ -219,7 +219,7 @@ private:
     ENABLE_OBJWIN = 7
   };
 
-  void LatchEnabledBGs();
+  void LatchDISPCNT();
   void LatchBGXYWrites();
   void CheckVerticalCounterIRQ();
   void UpdateVideoTransferDMA();

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -259,7 +259,7 @@ private:
 
     u32 buffer[240][4];
 
-    int mosaic_counter;
+    int mosaic_y;
   } bg;
 
   void InitBackground();
@@ -273,7 +273,7 @@ private:
     u64 timestamp_oam_access = ~0ULL;
     uint cycle;
     uint vcount;
-    int mosaic_counter;
+    int mosaic_y;
 
     struct {
       uint index;

--- a/src/nba/src/hw/ppu/registers.cpp
+++ b/src/nba/src/hw/ppu/registers.cpp
@@ -175,17 +175,14 @@ void ReferencePoint::Write(int address, u8 value) {
 void WindowRange::Reset() {
   min = 0;
   max = 0;
-  _changed = true;
 }
 
 void WindowRange::Write(int address, u8 value) {
   switch (address) {
     case 0:
-      if (value != max) _changed = true;
       max = value;
       break;
     case 1:
-      if (value != min) _changed = true;
       min = value;
       break;
   }

--- a/src/nba/src/hw/ppu/registers.cpp
+++ b/src/nba/src/hw/ppu/registers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/ppu/registers.cpp
+++ b/src/nba/src/hw/ppu/registers.cpp
@@ -16,23 +16,9 @@ void DisplayControl::Reset() {
 }
 
 auto DisplayControl::Read(int address) -> u8 {
-  switch (address) {
-    case 0:
-      return mode |
-            (cgb_mode << 3) |
-            (frame << 4) |
-            (hblank_oam_access << 5) |
-            (oam_mapping_1d << 6) |
-            (forced_blank << 7);
-    case 1:
-      return enable[0] |
-            (enable[1] << 1) |
-            (enable[2] << 2) |
-            (enable[3] << 3) |
-            (enable[4] << 4) |
-            (enable[5] << 5) |
-            (enable[6] << 6) |
-            (enable[7] << 7);
+  switch(address) {
+    case 0: return (u8)(hword >> 0);
+    case 1: return (u8)(hword >> 8);
   }
 
   return 0;
@@ -40,7 +26,9 @@ auto DisplayControl::Read(int address) -> u8 {
 
 void DisplayControl::Write(int address, u8 value) {
   switch (address) {
-    case 0:
+    case 0: {
+      hword = (hword & 0xFF00) | value;
+
       mode = value & 7;
       cgb_mode = (value >> 3) & 1;
       frame = (value >> 4) & 1;
@@ -48,11 +36,15 @@ void DisplayControl::Write(int address, u8 value) {
       oam_mapping_1d = (value >> 6) & 1;
       forced_blank = (value >> 7) & 1;
       break;
-    case 1:
+    }
+    case 1: {
+      hword = (hword & 0x00FF) | (value << 8);
+
       for (int i = 0; i < 8; i++) {
         enable[i] = (value >> i) & 1;
       }
       break;
+    }
   }
 }
 

--- a/src/nba/src/hw/ppu/registers.hpp
+++ b/src/nba/src/hw/ppu/registers.hpp
@@ -14,6 +14,8 @@ namespace nba::core {
 class PPU;
 
 struct DisplayControl {
+  u16 hword;
+
   int mode;
   int cgb_mode;
   int frame;

--- a/src/nba/src/hw/ppu/registers.hpp
+++ b/src/nba/src/hw/ppu/registers.hpp
@@ -106,7 +106,6 @@ struct BlendControl {
 struct WindowRange {
   int min;
   int max;
-  bool _changed;
 
   void Reset();
   void Write(int address, u8 value);

--- a/src/nba/src/hw/ppu/registers.hpp
+++ b/src/nba/src/hw/ppu/registers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/ppu/serialization.cpp
+++ b/src/nba/src/hw/ppu/serialization.cpp
@@ -12,11 +12,93 @@
 namespace nba::core {
 
 void PPU::LoadState(SaveState const& state) {
-  // @todo: implement this
+  auto& ss_ppu = state.ppu;
+  auto& mosaic = mmio.mosaic;
+
+  /**
+   * We have to restore VCOUNT before DISPSTAT,
+   * because otherwise loading DISPSTAT might (incorrectly) trigger a V-count IRQ.
+   */
+  mmio.vcount = ss_ppu.io.vcount;
+
+  mmio.dispcnt.WriteHalf(ss_ppu.io.dispcnt);
+  mmio.greenswap = ss_ppu.io.greenswap;
+  mmio.dispstat.WriteHalf(ss_ppu.io.dispstat);
+
+  for(int id = 0; id < 4; id++) {
+    mmio.bgcnt[id].WriteHalf(ss_ppu.io.bgcnt[id]);
+    mmio.bghofs[id] = ss_ppu.io.bghofs[id];
+    mmio.bgvofs[id] = ss_ppu.io.bgvofs[id];
+  }
+
+  for(int id = 0; id < 2; id++) {
+    mmio.bgpa[id] = ss_ppu.io.bgpa[id];
+    mmio.bgpb[id] = ss_ppu.io.bgpb[id];
+    mmio.bgpc[id] = ss_ppu.io.bgpc[id];
+    mmio.bgpd[id] = ss_ppu.io.bgpd[id];
+
+    // @todo: restore 'current' and 'written' fields
+    mmio.bgx[id].initial = (s32)ss_ppu.io.bgx[id];
+    mmio.bgy[id].initial = (s32)ss_ppu.io.bgy[id];
+
+    mmio.winh[id].WriteHalf(ss_ppu.io.winh[id]);
+    mmio.winv[id].WriteHalf(ss_ppu.io.winv[id]);
+  }
+
+  mmio.winin.WriteHalf(ss_ppu.io.winin);
+  mmio.winout.WriteHalf(ss_ppu.io.winout);
+
+  mosaic.bg.size_x  = (ss_ppu.io.mosaic >>  0) & 15;
+  mosaic.bg.size_y  = (ss_ppu.io.mosaic >>  4) & 15;
+  mosaic.obj.size_x = (ss_ppu.io.mosaic >>  8) & 15;
+  mosaic.obj.size_y =  ss_ppu.io.mosaic >> 12;
+
+  mmio.bldcnt.WriteHalf(ss_ppu.io.bldcnt);
+  mmio.eva = ss_ppu.io.bldalpha & 31;
+  mmio.evb = (ss_ppu.io.bldalpha >> 8) & 31;
+  mmio.evy = ss_ppu.io.bldy & 31;
 }
 
 void PPU::CopyState(SaveState& state) {
-  // @todo: implement this
+  auto& ss_ppu = state.ppu;
+  auto& mosaic = mmio.mosaic;
+
+  ss_ppu.io.dispcnt = mmio.dispcnt.ReadHalf();
+  ss_ppu.io.greenswap = mmio.greenswap;
+  ss_ppu.io.dispstat = mmio.dispstat.ReadHalf();
+  ss_ppu.io.vcount = mmio.vcount;
+  
+  for(int id = 0; id < 4; id++) {
+    ss_ppu.io.bgcnt[id] = mmio.bgcnt[id].ReadHalf();
+    ss_ppu.io.bghofs[id] = mmio.bghofs[id];
+    ss_ppu.io.bgvofs[id] = mmio.bgvofs[id];
+  }
+
+  for(int id = 0; id < 2; id++) {
+    ss_ppu.io.bgpa[id] = mmio.bgpa[id];
+    ss_ppu.io.bgpb[id] = mmio.bgpb[id];
+    ss_ppu.io.bgpc[id] = mmio.bgpc[id];
+    ss_ppu.io.bgpd[id] = mmio.bgpd[id];
+    
+    // @todo: save 'current' and 'written' fields (separately though).
+    ss_ppu.io.bgx[id] = (u32)mmio.bgx[id].initial;
+    ss_ppu.io.bgy[id] = (u32)mmio.bgy[id].initial;
+
+    ss_ppu.io.winh[id] = mmio.winh[id].ReadHalf();
+    ss_ppu.io.winv[id] = mmio.winv[id].ReadHalf();
+  }
+
+  ss_ppu.io.winin  = mmio.winin.ReadHalf();
+  ss_ppu.io.winout = mmio.winout.ReadHalf();
+
+  ss_ppu.io.mosaic = mosaic.bg.size_x  << 0 |
+                     mosaic.bg.size_y  << 4 |
+                     mosaic.obj.size_x << 8 |
+                     mosaic.obj.size_y << 12;
+  
+  ss_ppu.io.bldcnt = mmio.bldcnt.ReadHalf();
+  ss_ppu.io.bldalpha = mmio.eva | (mmio.evb << 8);
+  ss_ppu.io.bldy = mmio.evy;
 }
 
 } // namespace nba::core

--- a/src/nba/src/hw/ppu/serialization.cpp
+++ b/src/nba/src/hw/ppu/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -211,7 +211,7 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
             const int leftmost_x = center_x - half_width;
 
             if(leftmost_x < 0) {
-              const int clip = -leftmost_x & (affine ? 0: ~1);
+              const int clip = -leftmost_x & (affine ? ~0 : ~1);
 
               drawer_state.draw_x += clip;
               drawer_state.remaining_pixels -= clip;

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -172,10 +172,9 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
           // @todo: implement vertical sprite mosaic
           const int line = (sprite.vcount + 1) % 228;
 
-          const int center_y = y + half_height;
-          const int local_y = line - center_y;
+          const int y_max = y + half_height * 2;
 
-          if(local_y >= -half_height && local_y < half_height) {
+          if(line >= y && line < y_max) {
             drawer_state.width = width;
             drawer_state.height = height;
             drawer_state.mode = mode;
@@ -201,7 +200,7 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
               oam_fetch.pending_wait = half_width - 2;
             } else {
               oam_fetch.initial_local_x = -half_width;
-              oam_fetch.initial_local_y = local_y;
+              oam_fetch.initial_local_y = line - ((y + y_max) >> 1);
               oam_fetch.pending_wait = half_width * 2 - 1;
               oam_fetch.matrix_address = (((attr01 >> 25) & 31U) * 32U) + 6U;
             }

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -47,7 +47,7 @@ void PPU::InitSprite() {
   sprite.timestamp_init = timestamp_now;
   sprite.timestamp_last_sync = timestamp_now;
   sprite.cycle = 0U;
-  sprite.vcount = vcount;
+  sprite.vcount = (vcount + 1) % 228;
   sprite.mosaic_counter = mmio.mosaic.obj._counter_y;
 
   sprite.oam_fetch.index = 0U;
@@ -168,17 +168,14 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
             }
           }
 
-          // @todo: this can be precalculated at the start of the scanline
-          int line = (sprite.vcount + 1) % 228;
+          const int vcount = sprite.vcount;
 
           const int y_max = (y + half_height * 2) & 255;
 
-          if((line >= y || y_max < y) && line < y_max) {
+          if((vcount >= y || y_max < y) && vcount < y_max) {
             const bool mosaic = attr01 & (1 << 12);
 
-            if(mosaic) {
-              line -= sprite.mosaic_counter;
-            }
+            const int line = sprite.vcount - (mosaic ? sprite.mosaic_counter : 0);
 
             drawer_state.width = width;
             drawer_state.height = height;

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -48,6 +48,7 @@ void PPU::InitSprite() {
   sprite.timestamp_last_sync = timestamp_now;
   sprite.cycle = 0U;
   sprite.vcount = vcount;
+  sprite.mosaic_counter = mmio.mosaic.obj._counter_y;
 
   sprite.oam_fetch.index = 0U;
   sprite.oam_fetch.step = 0;
@@ -168,16 +169,21 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
           }
 
           // @todo: this can be precalculated at the start of the scanline
-          // @todo: implement vertical sprite mosaic
-          const int line = (sprite.vcount + 1) % 228;
+          int line = (sprite.vcount + 1) % 228;
 
           const int y_max = (y + half_height * 2) & 255;
 
           if((line >= y || y_max < y) && line < y_max) {
+            const bool mosaic = attr01 & (1 << 12);
+
+            if(mosaic) {
+              line -= sprite.mosaic_counter;
+            }
+
             drawer_state.width = width;
             drawer_state.height = height;
             drawer_state.mode = mode;
-            drawer_state.mosaic = attr01 & (1 << 12);
+            drawer_state.mosaic = mosaic;
             drawer_state.affine = affine;
             drawer_state.draw_x = x;
             drawer_state.remaining_pixels = half_width << 1;

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -172,7 +172,6 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
           // @todo: implement vertical sprite mosaic
           const int line = (sprite.vcount + 1) % 228;
 
-          const int center_x = x + half_width;
           const int center_y = y + half_height;
           const int local_y = line - center_y;
 
@@ -209,10 +208,8 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
 
             active = true;
 
-            const int leftmost_x = center_x - half_width;
-
-            if(leftmost_x < 0) {
-              const int clip = -leftmost_x & (affine ? ~0 : ~1);
+            if(x < 0) {
+              const int clip = -x & (affine ? ~0 : ~1);
 
               drawer_state.draw_x += clip;
               drawer_state.remaining_pixels -= clip;

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -318,8 +318,6 @@ void PPU::DrawSpriteFetchVRAM(uint cycle) {
       return;
     }
 
-    const int x = drawer_state.draw_x++;
-    
     const int texture_x = drawer_state.texture_x >> 8;
     const int texture_y = drawer_state.texture_y >> 8;
 
@@ -352,9 +350,11 @@ void PPU::DrawSpriteFetchVRAM(uint cycle) {
         }
       }
 
-      Plot(x, color_index);
+      Plot(drawer_state.draw_x, color_index);
     }
   
+    drawer_state.draw_x++;
+
     drawer_state.texture_x += drawer_state.matrix[0];
     drawer_state.texture_y += drawer_state.matrix[2];
 
@@ -401,17 +401,14 @@ void PPU::DrawSpriteFetchVRAM(uint cycle) {
       palette = drawer_state.palette << 4;
     }
 
-    // @todo: try to optimize this a bit.
     for(int i = 0; i < 2; i++) {
-      const int x = drawer_state.draw_x++;
-
       uint color_index = color_indices[i];
 
       if(color_index > 0U) {
         color_index |= palette;
       }
 
-      Plot(x, color_index);
+      Plot(drawer_state.draw_x++, color_index);
     }
 
     drawer_state.texture_x += 2;

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -48,7 +48,6 @@ void PPU::InitSprite() {
   sprite.timestamp_last_sync = timestamp_now;
   sprite.cycle = 0U;
   sprite.vcount = (vcount + 1) % 228;
-  sprite.mosaic_y = mmio.mosaic.obj._counter_y;
 
   sprite.oam_fetch.index = 0U;
   sprite.oam_fetch.step = 0;
@@ -92,6 +91,18 @@ void PPU::DrawSpriteImpl(int cycles) {
     if(mmio.dispcnt.enable[LAYER_OBJ] && (cycle & 1U) == 0U) {
       DrawSpriteFetchVRAM(cycle);
       DrawSpriteFetchOAM(cycle);
+    }
+
+    if(cycle == 966U) { // cycle 1006 in the scanline
+      auto& mosaic = mmio.mosaic;
+
+      if(sprite.vcount < 159) {
+        if (++mosaic.obj._counter_y == mosaic.obj.size_y) {
+          mosaic.obj._counter_y = 0;
+        }
+      } else {
+        mosaic.obj._counter_y = 0;
+      }
     }
 
     if(++sprite.cycle == cycle_limit) {
@@ -175,7 +186,8 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
           if((vcount >= y || y_max < y) && vcount < y_max) {
             const bool mosaic = attr01 & (1 << 12);
 
-            const int line = sprite.vcount - (mosaic ? sprite.mosaic_y : 0);
+            const int mosaic_y = mmio.mosaic.obj._counter_y;
+            const int line = sprite.vcount - (mosaic ? mosaic_y : 0);
 
             drawer_state.width = width;
             drawer_state.height = height;

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -48,7 +48,7 @@ void PPU::InitSprite() {
   sprite.timestamp_last_sync = timestamp_now;
   sprite.cycle = 0U;
   sprite.vcount = (vcount + 1) % 228;
-  sprite.mosaic_counter = mmio.mosaic.obj._counter_y;
+  sprite.mosaic_y = mmio.mosaic.obj._counter_y;
 
   sprite.oam_fetch.index = 0U;
   sprite.oam_fetch.step = 0;
@@ -175,7 +175,7 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
           if((vcount >= y || y_max < y) && vcount < y_max) {
             const bool mosaic = attr01 & (1 << 12);
 
-            const int line = sprite.vcount - (mosaic ? sprite.mosaic_counter : 0);
+            const int line = sprite.vcount - (mosaic ? sprite.mosaic_y : 0);
 
             drawer_state.width = width;
             drawer_state.height = height;

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -146,7 +146,6 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
           s32 y =  attr01 & 0xFF;
 
           if(x >= 240) x -= 512;
-          if(y >= 160) y -= 256;
 
           const uint shape = (attr01 >> 14) & 3U;
           const uint size  =  attr01 >> 30;
@@ -172,9 +171,9 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
           // @todo: implement vertical sprite mosaic
           const int line = (sprite.vcount + 1) % 228;
 
-          const int y_max = y + half_height * 2;
+          const int y_max = (y + half_height * 2) & 255;
 
-          if(line >= y && line < y_max) {
+          if((line >= y || y_max < y) && line < y_max) {
             drawer_state.width = width;
             drawer_state.height = height;
             drawer_state.mode = mode;
@@ -191,7 +190,7 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
               drawer_state.flip_h = attr01 & (1 << 28);
 
               drawer_state.texture_x = 0;
-              drawer_state.texture_y = line - y;
+              drawer_state.texture_y = (line - y) & 255;
 
               if(flip_v) {
                 drawer_state.texture_y ^= height - 1;
@@ -200,7 +199,7 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
               oam_fetch.pending_wait = half_width - 2;
             } else {
               oam_fetch.initial_local_x = -half_width;
-              oam_fetch.initial_local_y = line - ((y + y_max) >> 1);
+              oam_fetch.initial_local_y = line - (y_max - half_height);
               oam_fetch.pending_wait = half_width * 2 - 1;
               oam_fetch.matrix_address = (((attr01 >> 25) & 31U) * 32U) + 6U;
             }

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -207,6 +207,27 @@ void PPU::DrawSpriteFetchOAM(uint cycle) {
             }
 
             active = true;
+
+            const int leftmost_x = center_x - half_width;
+
+            if(leftmost_x < 0) {
+              const int clip = -leftmost_x & (affine ? 0: ~1);
+
+              drawer_state.draw_x += clip;
+              drawer_state.remaining_pixels -= clip;
+
+              if(affine) {
+                oam_fetch.pending_wait -= clip;
+                oam_fetch.initial_local_x += clip;
+              } else {
+                oam_fetch.pending_wait -= clip >> 1;
+                drawer_state.texture_x += clip;
+              }
+
+              if(drawer_state.remaining_pixels <= 0) {
+                active = false;
+              }
+            }
           }
         }
       }

--- a/src/nba/src/hw/ppu/sprite.cpp
+++ b/src/nba/src/hw/ppu/sprite.cpp
@@ -386,7 +386,7 @@ void PPU::DrawSpriteFetchVRAM(uint cycle) {
     const int texture_x = drawer_state.texture_x ^ (flip_h ? (width - 1) : 0);
     const int texture_y = drawer_state.texture_y;
 
-    const int tile_x  = texture_x & 7;
+    const int tile_x  = texture_x & 7 & ~1;
     const int tile_y  = texture_y & 7;
     const int block_x = texture_x >> 3;
     const int block_y = texture_y >> 3;

--- a/src/nba/src/hw/ppu/window.cpp
+++ b/src/nba/src/hw/ppu/window.cpp
@@ -38,7 +38,7 @@ void PPU::DrawWindow() {
   }
 
   for(int i = 0; i < cycles; i++) {
-    if((window.cycle & 3) == 0) {
+    if((window.cycle & 3U) == 0U) {
       const uint x = window.cycle >> 2;
 
       for(int i = 0; i < 2; i++) {

--- a/src/nba/src/hw/ppu/window.cpp
+++ b/src/nba/src/hw/ppu/window.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 fleroviux
+ *
+ * Licensed under GPLv3 or any later version.
+ * Refer to the included LICENSE file.
+ */
+
+#include "ppu.hpp"
+
+namespace nba::core {
+
+void PPU::InitWindow() {
+  const int vcount = mmio.vcount;
+
+  for(int i = 0; i < 2; i++) {
+    const auto& winv = mmio.winv[i];
+
+    if(vcount == winv.min) {
+      window.v_flag[i] = true;
+    }
+
+    if(vcount == winv.max) {
+      window.v_flag[i] = false;
+    }
+  }
+
+  window.timestamp_last_sync = scheduler.GetTimestampNow();
+  window.cycle = 0;
+}
+
+void PPU::DrawWindow() {
+  const u64 timestamp_now = scheduler.GetTimestampNow();
+
+  const int cycles = (int)(timestamp_now - window.timestamp_last_sync);
+
+  if(cycles == 0 || window.cycle >= 1024U) {
+    return;
+  }
+
+  for(int i = 0; i < cycles; i++) {
+    if((window.cycle & 3) == 0) {
+      const uint x = window.cycle >> 2;
+
+      for(int i = 0; i < 2; i++) {
+        const auto& winh = mmio.winh[i];
+
+        if(x == winh.min) {
+          window.h_flag[i] = true;
+        }
+
+        if(x == winh.max) {
+          window.h_flag[i] = false;
+        }
+
+        if(x < 240) {
+          window.buffer[x][i] = window.h_flag[i] && window.v_flag[i];
+        }
+      }
+    }
+
+    if(++window.cycle == 1024U) {
+      break;
+    }
+  }
+
+  window.timestamp_last_sync = timestamp_now;
+}
+
+} // namespace nba::core

--- a/src/nba/src/hw/rom/backup/eeprom.cpp
+++ b/src/nba/src/hw/rom/backup/eeprom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/rom/backup/flash.cpp
+++ b/src/nba/src/hw/rom/backup/flash.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/rom/backup/serialization.cpp
+++ b/src/nba/src/hw/rom/backup/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/rom/backup/sram.cpp
+++ b/src/nba/src/hw/rom/backup/sram.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/rom/gpio/gpio.cpp
+++ b/src/nba/src/hw/rom/gpio/gpio.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/rom/gpio/rtc.cpp
+++ b/src/nba/src/hw/rom/gpio/rtc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/rom/gpio/serialization.cpp
+++ b/src/nba/src/hw/rom/gpio/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/rom/gpio/solar_sensor.cpp
+++ b/src/nba/src/hw/rom/gpio/solar_sensor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/timer/serialization.cpp
+++ b/src/nba/src/hw/timer/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/timer/timer.cpp
+++ b/src/nba/src/hw/timer/timer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/hw/timer/timer.hpp
+++ b/src/nba/src/hw/timer/timer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/nba/src/serialization.cpp
+++ b/src/nba/src/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/config.hpp
+++ b/src/platform/core/include/platform/config.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/device/ogl_video_device.hpp
+++ b/src/platform/core/include/platform/device/ogl_video_device.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/device/sdl_audio_device.hpp
+++ b/src/platform/core/include/platform/device/sdl_audio_device.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/emulator_thread.hpp
+++ b/src/platform/core/include/platform/emulator_thread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/frame_limiter.hpp
+++ b/src/platform/core/include/platform/frame_limiter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/game_db.hpp
+++ b/src/platform/core/include/platform/game_db.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/loader/bios.hpp
+++ b/src/platform/core/include/platform/loader/bios.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/loader/rom.hpp
+++ b/src/platform/core/include/platform/loader/rom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/loader/save_state.hpp
+++ b/src/platform/core/include/platform/loader/save_state.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/include/platform/writer/save_state.hpp
+++ b/src/platform/core/include/platform/writer/save_state.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/config.cpp
+++ b/src/platform/core/src/config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/device/sdl_audio_device.cpp
+++ b/src/platform/core/src/device/sdl_audio_device.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/device/shader/common.glsl.hpp
+++ b/src/platform/core/src/device/shader/common.glsl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/device/shader/lcd_ghosting.glsl.hpp
+++ b/src/platform/core/src/device/shader/lcd_ghosting.glsl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/device/shader/output.glsl.hpp
+++ b/src/platform/core/src/device/shader/output.glsl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/emulator_thread.cpp
+++ b/src/platform/core/src/emulator_thread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/frame_limiter.cpp
+++ b/src/platform/core/src/frame_limiter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/game_db.cpp
+++ b/src/platform/core/src/game_db.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/loader/bios.cpp
+++ b/src/platform/core/src/loader/bios.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/loader/rom.cpp
+++ b/src/platform/core/src/loader/rom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/loader/save_state.cpp
+++ b/src/platform/core/src/loader/save_state.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/core/src/writer/save_state.cpp
+++ b/src/platform/core/src/writer/save_state.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/rc/app.rc
+++ b/src/platform/qt/rc/app.rc
@@ -4,8 +4,8 @@
 IDI_ICON1 ICON DISCARDABLE "app.ico"
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION     1,5
-PRODUCTVERSION  1,5
+FILEVERSION     1,6
+PRODUCTVERSION  1,6
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -15,7 +15,7 @@ BEGIN
             VALUE "FileDescription",    "NanoBoyAdvance"
             VALUE "FileVersion",        "1.6"
             VALUE "InternalName",       "NanoBoyAdvance.exe"
-            VALUE "LegalCopyright",     "(c) 2015 - 2022 fleroviux"
+            VALUE "LegalCopyright",     "(c) 2015 - 2023 fleroviux"
             VALUE "OriginalFilename",   "NanoBoyAdvance.exe"
             VALUE "ProductName",        "NanoBoyAdvance"
             VALUE "ProductVersion",     "1.6"

--- a/src/platform/qt/src/config.cpp
+++ b/src/platform/qt/src/config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/config.hpp
+++ b/src/platform/qt/src/config.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/main.cpp
+++ b/src/platform/qt/src/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/widget/controller_manager.cpp
+++ b/src/platform/qt/src/widget/controller_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/widget/controller_manager.hpp
+++ b/src/platform/qt/src/widget/controller_manager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/widget/input_window.cpp
+++ b/src/platform/qt/src/widget/input_window.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/widget/input_window.hpp
+++ b/src/platform/qt/src/widget/input_window.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/widget/main_window.cpp
+++ b/src/platform/qt/src/widget/main_window.cpp
@@ -366,7 +366,7 @@ void MainWindow::CreateHelpMenu() {
     QMessageBox box{ this };
     box.setTextFormat(Qt::RichText);
     box.setText(tr("NanoBoyAdvance is a Game Boy Advance emulator focused on accuracy.<br><br>"
-                   "Copyright © 2015 - 2022 fleroviux<br><br>"
+                   "Copyright © 2015 - 2023 fleroviux<br><br>"
                    "NanoBoyAdvance is licensed under the GPLv3 or any later version.<br><br>"
                    "GitHub: <a href=\"https://github.com/nba-emu/NanoBoyAdvance\">https://github.com/nba-emu/NanoBoyAdvance</a><br><br>"
                    "Game Boy Advance is a registered trademark of Nintendo Co., Ltd."));

--- a/src/platform/qt/src/widget/main_window.cpp
+++ b/src/platform/qt/src/widget/main_window.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/widget/main_window.hpp
+++ b/src/platform/qt/src/widget/main_window.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/widget/screen.cpp
+++ b/src/platform/qt/src/widget/screen.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.

--- a/src/platform/qt/src/widget/screen.hpp
+++ b/src/platform/qt/src/widget/screen.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 fleroviux
+ * Copyright (C) 2023 fleroviux
  *
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.


### PR DESCRIPTION
This PR implements cycle-accurate emulation for the PPU.
The goal is to be as close as possible to real hardware. However despite my effort to reverse-engineer the PPU, some details remain unknown. So for now some inaccuracies will still exist that probably can be ironed out in the future.

This PR supersedes https://github.com/nba-emu/NanoBoyAdvance/pull/258 (an earlier attempt at implementing my findings)

## TODO

- [x] implement mosaic
- [x] DMAs should not trigger while the CPU is being stalled by the PPU
- [x] figure out the DISPCNT latch mess
- [x] implement forced-blank bit
- [x] fix bugs due to state updates that happen at the start of h-blank (i.e. affine registers)
- [x] do 2nd layer palette lookup two cycles later
- [x] handle the 6-th green channel bit during blending
- [x] do not sync the PPU on every IO write (even non-PPU IO)
- [ ] adjust scanline timings to be exact (optional) (can be done after this PR)
- [x] implement save states
- [ ] optimize code
- [ ] cleanup code
- [x] perform regression tests

