### PR TITLE
Rework the scheduler to allow for proper (de)serialization of events

### DIFF
--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -297,6 +297,7 @@ struct SaveState {
     struct Event {
       u64 key;
       u64 uid;
+      u64 user_data;
       u16 event_class;
     } events[64];
 

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -211,6 +211,8 @@ struct SaveState {
       u16 reload;
       u16 control;
     } pending;
+
+    u64 event_uid;
   } timer[4];
 
   struct DMA {

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -296,6 +296,7 @@ struct SaveState {
   struct Scheduler {
     struct Event {
       u64 key;
+      u64 uid;
       u16 event_class;
     } events[64];
 

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -230,7 +230,8 @@ struct SaveState {
       } latch;
 
       bool is_fifo_dma;
-      u64 enable_event_timestamp;
+
+      u64 event_uid;
     } channels[4];
 
     u8 hblank_set;

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -292,6 +292,15 @@ struct SaveState {
   } gpio;
 
   u16 keycnt;
+
+  struct Scheduler {
+    struct Event {
+      u64 key;
+      u16 event_class;
+    } events[64];
+
+    int event_count;
+  } scheduler;
 };
 
 } // namespace nba

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -299,7 +299,8 @@ struct SaveState {
       u16 event_class;
     } events[64];
 
-    int event_count;
+    u8 event_count;
+    u64 next_uid;
   } scheduler;
 };
 

--- a/src/nba/include/nba/save_state.hpp
+++ b/src/nba/include/nba/save_state.hpp
@@ -154,6 +154,8 @@ struct SaveState {
           u8 shift;
           u8 step;
         } sweep;
+
+        u64 event_uid;
       };
 
       struct QuadChannel : PSG {

--- a/src/nba/src/arm/arm7tdmi.hpp
+++ b/src/nba/src/arm/arm7tdmi.hpp
@@ -24,6 +24,8 @@ struct ARM7TDMI {
   ARM7TDMI(Scheduler& scheduler, Bus& bus)
       : scheduler(scheduler)
       , bus(bus) {
+    scheduler.Register(Scheduler::EventClass::ARM_ldm_usermode_conflict, this, &ARM7TDMI::ClearLDMUsermodeConflictFlag);
+
     Reset();
   }
 
@@ -257,6 +259,10 @@ private:
     }
 
     return BANK_INVALID;
+  }
+
+  void ClearLDMUsermodeConflictFlag() {
+    ldm_usermode_conflict = false;
   }
 
   #include "handlers/arithmetic.inl"

--- a/src/nba/src/arm/handlers/handler32.inl
+++ b/src/nba/src/arm/handlers/handler32.inl
@@ -622,9 +622,7 @@ void ARM_BlockDataTransfer(u32 instruction) {
        * register accesses will go to both the user bank and original bank.
        */
       ldm_usermode_conflict = true;
-      scheduler.Add(2, [this](int late) {
-        ldm_usermode_conflict = false;
-      });
+      scheduler.Add(2, Scheduler::EventClass::ARM_ldm_usermode_conflict);
     }
 
     if (transfer_pc) {

--- a/src/nba/src/hw/apu/apu.hpp
+++ b/src/nba/src/hw/apu/apu.hpp
@@ -43,8 +43,8 @@ struct APU {
 
   struct MMIO {
     MMIO(Scheduler& scheduler)
-        : psg1(scheduler)
-        , psg2(scheduler)
+        : psg1(scheduler, Scheduler::EventClass::APU_PSG1_generate)
+        , psg2(scheduler, Scheduler::EventClass::APU_PSG2_generate)
         , psg3(scheduler)
         , psg4(scheduler, bias) {
     }

--- a/src/nba/src/hw/apu/apu.hpp
+++ b/src/nba/src/hw/apu/apu.hpp
@@ -70,8 +70,8 @@ struct APU {
   std::unique_ptr<StereoResampler<float>> resampler;
 
 private:
-  void StepMixer(int cycles_late);
-  void StepSequencer(int cycles_late);
+  void StepMixer();
+  void StepSequencer();
 
   s8 latch[2];
   std::shared_ptr<RingBuffer<float>> fifo_buffer[2];

--- a/src/nba/src/hw/apu/channel/noise_channel.cpp
+++ b/src/nba/src/hw/apu/channel/noise_channel.cpp
@@ -14,6 +14,8 @@ NoiseChannel::NoiseChannel(Scheduler& scheduler, BIAS& bias)
     : BaseChannel(true, false)
     , scheduler(scheduler)
     , bias(bias) {
+  scheduler.Register(Scheduler::EventClass::APU_PSG4_generate, this, &NoiseChannel::Generate);
+  
   Reset();
 }
 
@@ -32,7 +34,7 @@ void NoiseChannel::Reset() {
   event = nullptr;
 }
 
-void NoiseChannel::Generate(int cycles_late) {
+void NoiseChannel::Generate() {
   if (!IsEnabled()) {
     sample = 0;
     event = nullptr;
@@ -80,7 +82,7 @@ void NoiseChannel::Generate(int cycles_late) {
     skip_count = 0;
   }
 
-  event = scheduler.Add(noise_interval - cycles_late, event_cb);
+  event = scheduler.Add(noise_interval, Scheduler::EventClass::APU_PSG4_generate);
 }
 
 auto NoiseChannel::Read(int offset) -> u8 {
@@ -160,7 +162,7 @@ void NoiseChannel::Write(int offset, u8 value) {
           if(event) {
             scheduler.Cancel(event);
           }
-          event = scheduler.Add(GetSynthesisInterval(frequency_ratio, frequency_shift), event_cb);
+          event = scheduler.Add(GetSynthesisInterval(frequency_ratio, frequency_shift), Scheduler::EventClass::APU_PSG4_generate);
         }
 
         static constexpr u16 lfsr_init[] = { 0x4000, 0x0040 };

--- a/src/nba/src/hw/apu/channel/noise_channel.hpp
+++ b/src/nba/src/hw/apu/channel/noise_channel.hpp
@@ -22,7 +22,7 @@ public:
 
   void Reset();
   auto GetSample() -> s8 override { return sample; }
-  void Generate(int cycles_late);
+  void Generate();
   auto Read (int offset) -> u8;
   void Write(int offset, u8 value);
 
@@ -47,10 +47,6 @@ private:
 
   Scheduler& scheduler;
   Scheduler::Event* event;
-
-  std::function<void(int)> event_cb = [this](int cycles_late) {
-    this->Generate(cycles_late);
-  };
 
   int frequency_shift;
   int frequency_ratio;

--- a/src/nba/src/hw/apu/channel/quad_channel.cpp
+++ b/src/nba/src/hw/apu/channel/quad_channel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2023 fleroviux
- *
+ *<<
  * Licensed under GPLv3 or any later version.
  * Refer to the included LICENSE file.
  */
@@ -9,9 +9,12 @@
 
 namespace nba::core {
 
-QuadChannel::QuadChannel(Scheduler& scheduler)
+QuadChannel::QuadChannel(Scheduler& scheduler, Scheduler::EventClass event_class)
     : BaseChannel(true, true)
-    , scheduler(scheduler) {
+    , scheduler(scheduler)
+    , event_class(event_class) {
+  scheduler.Register(event_class, this, &QuadChannel::Generate);
+
   Reset();
 }
 
@@ -24,7 +27,7 @@ void QuadChannel::Reset() {
   event = nullptr;
 }
 
-void QuadChannel::Generate(int cycles_late) {
+void QuadChannel::Generate() {
   if (!IsEnabled()) {
     sample = 0;
     event = nullptr;
@@ -45,7 +48,7 @@ void QuadChannel::Generate(int cycles_late) {
   }
   phase = (phase + 1) % 8;
 
-  event = scheduler.Add(GetSynthesisIntervalFromFrequency(sweep.current_freq) - cycles_late, event_cb);
+  event = scheduler.Add(GetSynthesisIntervalFromFrequency(sweep.current_freq), event_class);
 }
 
 auto QuadChannel::Read(int offset) -> u8 {
@@ -139,7 +142,7 @@ void QuadChannel::Write(int offset, u8 value) {
           if(event) {
             scheduler.Cancel(event);
           }
-          event = scheduler.Add(GetSynthesisIntervalFromFrequency(sweep.current_freq), event_cb);
+          event = scheduler.Add(GetSynthesisIntervalFromFrequency(sweep.current_freq), event_class);
         }
         phase = 0;
         Restart();

--- a/src/nba/src/hw/apu/channel/quad_channel.hpp
+++ b/src/nba/src/hw/apu/channel/quad_channel.hpp
@@ -16,11 +16,11 @@ namespace nba::core {
 
 class QuadChannel final : public BaseChannel {
 public:
-  QuadChannel(Scheduler& scheduler);
+  QuadChannel(Scheduler& scheduler, Scheduler::EventClass event_class);
 
   void Reset();
   auto GetSample() -> s8 override { return sample; }
-  void Generate(int cycles_late);
+  void Generate();
   auto Read (int offset) -> u8;
   void Write(int offset, u8 value);
 
@@ -36,11 +36,8 @@ private:
   }
 
   Scheduler& scheduler;
+  Scheduler::EventClass event_class;
   Scheduler::Event* event;
-
-  std::function<void(int)> event_cb = [this](int cycles_late) {
-    this->Generate(cycles_late);
-  };
 
   s8 sample = 0;
   int phase;

--- a/src/nba/src/hw/apu/channel/wave_channel.hpp
+++ b/src/nba/src/hw/apu/channel/wave_channel.hpp
@@ -26,7 +26,7 @@ public:
   void Reset(ResetWaveRAM reset_wave_ram);
   bool IsEnabled() override { return playing && BaseChannel::IsEnabled(); }
   auto GetSample() -> s8 override { return sample; }
-  void Generate(int cycles_late);
+  void Generate();
   auto Read (int offset) -> u8;
   void Write(int offset, u8 value);
 
@@ -49,10 +49,6 @@ private:
 
   Scheduler& scheduler;
   Scheduler::Event* event = nullptr;
-
-  std::function<void(int)> event_cb = [this](int cycles_late) {
-    this->Generate(cycles_late);
-  };
 
   s8 sample = 0;
   bool playing;

--- a/src/nba/src/hw/apu/serialization.cpp
+++ b/src/nba/src/hw/apu/serialization.cpp
@@ -32,16 +32,6 @@ void APU::LoadState(SaveState const& state) {
 
   resolution_old = state.apu.resolution_old;
 
-  int mix_event_cycles = mmio.bias.GetSampleInterval();
-  int seq_event_cycles = BaseChannel::s_cycles_per_step;
-
-  // This works because these numbers are powers-of-two:
-  mix_event_cycles -= state.timestamp & (mix_event_cycles - 1);
-  seq_event_cycles -= state.timestamp & (seq_event_cycles - 1);
-
-  scheduler.Add(mix_event_cycles, this, &APU::StepMixer);
-  scheduler.Add(seq_event_cycles, this, &APU::StepSequencer);
-
   // We are simply resetting the MP2K mixer for now,
   // there probably is no need to do complicated (de)serialization.
   mp2k.Reset();

--- a/src/nba/src/hw/apu/serialization.cpp
+++ b/src/nba/src/hw/apu/serialization.cpp
@@ -121,11 +121,7 @@ void QuadChannel::LoadState(SaveState::APU::IO::QuadChannel const& state) {
   phase = state.phase;
   wave_duty = state.wave_duty;
   sample = state.sample;
-
-  if (dac_enable && IsEnabled()) {
-    // TODO: properly align event to system clock.
-    scheduler.Add(GetSynthesisIntervalFromFrequency(sweep.current_freq), event_cb);
-  }
+  event = scheduler.GetEventByUID(state.event_uid);
 }
 
 void QuadChannel::CopyState(SaveState::APU::IO::QuadChannel& state) {
@@ -135,6 +131,7 @@ void QuadChannel::CopyState(SaveState::APU::IO::QuadChannel& state) {
   state.phase = phase;
   state.wave_duty = wave_duty;
   state.sample = sample;
+  state.event_uid = GetEventUID(event);
 }
 
 void WaveChannel::LoadState(SaveState::APU::IO::WaveChannel const& state) {
@@ -147,13 +144,9 @@ void WaveChannel::LoadState(SaveState::APU::IO::WaveChannel const& state) {
   frequency = state.frequency;
   dimension = state.dimension;
   wave_bank = state.wave_bank;
+  event = scheduler.GetEventByUID(state.event_uid);
 
   std::memcpy(wave_ram, state.wave_ram, sizeof(wave_ram));
-
-  if (BaseChannel::IsEnabled()) {
-    // TODO: properly align event to system clock.
-    scheduler.Add(GetSynthesisIntervalFromFrequency(frequency), event_cb);
-  }
 }
 
 void WaveChannel::CopyState(SaveState::APU::IO::WaveChannel& state) {
@@ -166,6 +159,7 @@ void WaveChannel::CopyState(SaveState::APU::IO::WaveChannel& state) {
   state.frequency = frequency;
   state.dimension = dimension;
   state.wave_bank = wave_bank;
+  state.event_uid = GetEventUID(event);
 
   std::memcpy(state.wave_ram, wave_ram, sizeof(wave_ram));
 }
@@ -177,12 +171,7 @@ void NoiseChannel::LoadState(SaveState::APU::IO::NoiseChannel const& state) {
   frequency_shift = state.frequency_shift;
   frequency_ratio = state.frequency_ratio;
   width = state.width;
-
-  if (dac_enable && IsEnabled()) {
-    // TODO: properly handle skip count and properly align event to system clock.
-    skip_count = 0;
-    scheduler.Add(GetSynthesisInterval(frequency_ratio, frequency_shift), event_cb);
-  }
+  event = scheduler.GetEventByUID(state.event_uid);
 }
 
 void NoiseChannel::CopyState(SaveState::APU::IO::NoiseChannel& state) {
@@ -192,6 +181,7 @@ void NoiseChannel::CopyState(SaveState::APU::IO::NoiseChannel& state) {
   state.frequency_shift = frequency_shift;
   state.frequency_ratio = frequency_ratio;
   state.width = width;
+  state.event_uid = GetEventUID(event);
 }
 
 } // namespace nba::core

--- a/src/nba/src/hw/dma/dma.cpp
+++ b/src/nba/src/hw/dma/dma.cpp
@@ -91,13 +91,13 @@ void DMA::Reset() {
   }
 }
 
-void DMA::ScheduleDMAs(unsigned int bitset, int delay) {
+void DMA::ScheduleDMAs(unsigned int bitset) {
   while (bitset != 0) {
     auto chan_id = g_dma_from_bitset[bitset];
 
     bitset &= ~(1 << chan_id);
 
-    channels[chan_id].event = scheduler.Add(delay, Scheduler::EventClass::DMA_activated, 0, chan_id);
+    channels[chan_id].event = scheduler.Add(2, Scheduler::EventClass::DMA_activated, 0, chan_id);
   }
 }
 

--- a/src/nba/src/hw/dma/dma.cpp
+++ b/src/nba/src/hw/dma/dma.cpp
@@ -68,6 +68,15 @@ static constexpr char const* g_dma_time_name[] = {
   "audio"
 };
 
+DMA::DMA(Bus& bus, IRQ& irq, Scheduler& scheduler)
+    : bus(bus)
+    , irq(irq)
+    , scheduler(scheduler) {
+  scheduler.Register(Scheduler::EventClass::DMA_activated, this, &DMA::OnActivated);
+
+  Reset();
+}
+
 void DMA::Reset() {
   active_dma_id = g_dma_none_id;
   should_reenter_transfer_loop = false;
@@ -88,19 +97,21 @@ void DMA::ScheduleDMAs(unsigned int bitset, int delay) {
 
     bitset &= ~(1 << chan_id);
 
-    channels[chan_id].enable_event = scheduler.Add(delay, [this, chan_id](int cycles_late) {
-      channels[chan_id].enable_event = nullptr;
-
-      if (runnable_set.none()) {
-        active_dma_id = chan_id;
-      } else if (chan_id < active_dma_id) {
-        active_dma_id = chan_id;
-        should_reenter_transfer_loop = true;
-      }
-
-      runnable_set.set(chan_id, true);      
-    });
+    channels[chan_id].event = scheduler.Add(delay, Scheduler::EventClass::DMA_activated, 0, chan_id);
   }
+}
+
+void DMA::OnActivated(u64 chan_id) {
+  channels[chan_id].event = nullptr;
+
+  if (runnable_set.none()) {
+    active_dma_id = chan_id;
+  } else if (chan_id < active_dma_id) {
+    active_dma_id = chan_id;
+    should_reenter_transfer_loop = true;
+  }
+
+  runnable_set.set(chan_id, true);
 }
 
 void DMA::SelectNextDMA() {
@@ -400,7 +411,7 @@ void DMA::OnChannelWritten(Channel& channel, bool enable_old) {
       // DMA enable bit: 1 -> 1 (remains set)
 
       // Note: the DMA isn't really running, while it is still enabling.
-      if (channel.enable_event == nullptr) {
+      if (channel.event == nullptr) {
         AddChannelToDMASet(channel);
 
         /* When the config register of a DMA is written while it is running,
@@ -417,10 +428,10 @@ void DMA::OnChannelWritten(Channel& channel, bool enable_old) {
     runnable_set.set(channel.id, false);
 
     // Handle disabling the DMA before it started up.
-    if (channel.enable_event != nullptr) {
+    if (channel.event != nullptr) {
       // TODO: figure out exact hardware behaviour.
-      scheduler.Cancel(channel.enable_event);
-      channel.enable_event = nullptr;
+      scheduler.Cancel(channel.event);
+      channel.event = nullptr;
 
       Log<Warn>("DMA: disabled DMA{0} while it was starting.", channel.id);
     }

--- a/src/nba/src/hw/dma/dma.hpp
+++ b/src/nba/src/hw/dma/dma.hpp
@@ -19,12 +19,7 @@ namespace nba::core {
 struct Bus;
 
 struct DMA {
-  DMA(Bus& bus, IRQ& irq, Scheduler& scheduler)
-      : bus(bus)
-      , irq(irq)
-      , scheduler(scheduler) {
-    Reset();
-  }
+  DMA(Bus& bus, IRQ& irq, Scheduler& scheduler);
 
   enum class Occasion {
     HBlank,
@@ -95,7 +90,7 @@ private:
     } latch = {};
 
     bool is_fifo_dma = false;
-    Scheduler::Event* enable_event = nullptr;
+    Scheduler::Event* event = nullptr;
   } channels[4];
 
   constexpr int GetUnaliasedMemoryArea(int page) {
@@ -111,6 +106,8 @@ private:
   }
 
   void ScheduleDMAs(unsigned int bitset, int delay = 2);
+  void OnActivated(u64 chan_id);
+
   void SelectNextDMA();
   void OnChannelWritten(Channel& channel, bool enable_old);
   void AddChannelToDMASet(Channel& channel);

--- a/src/nba/src/hw/dma/dma.hpp
+++ b/src/nba/src/hw/dma/dma.hpp
@@ -105,7 +105,7 @@ private:
     return page;
   }
 
-  void ScheduleDMAs(unsigned int bitset, int delay);
+  void ScheduleDMAs(unsigned int bitset);
   void OnActivated(u64 chan_id);
 
   void SelectNextDMA();

--- a/src/nba/src/hw/dma/dma.hpp
+++ b/src/nba/src/hw/dma/dma.hpp
@@ -105,7 +105,7 @@ private:
     return page;
   }
 
-  void ScheduleDMAs(unsigned int bitset, int delay = 2);
+  void ScheduleDMAs(unsigned int bitset, int delay);
   void OnActivated(u64 chan_id);
 
   void SelectNextDMA();

--- a/src/nba/src/hw/dma/serialization.cpp
+++ b/src/nba/src/hw/dma/serialization.cpp
@@ -43,6 +43,7 @@ void DMA::LoadState(SaveState const& state) {
     channel_dst.latch.bus = channel_src.latch.bus;
 
     channel_dst.is_fifo_dma = channel_src.is_fifo_dma;
+
     channel_dst.event = scheduler.GetEventByUID(channel_src.event_uid);
   }
 }
@@ -77,6 +78,7 @@ void DMA::CopyState(SaveState& state) {
     channel_dst.latch.bus = channel_src.latch.bus;
 
     channel_dst.is_fifo_dma = channel_src.is_fifo_dma;
+
     channel_dst.event_uid = GetEventUID(channel_src.event);
   }
 }

--- a/src/nba/src/hw/dma/serialization.cpp
+++ b/src/nba/src/hw/dma/serialization.cpp
@@ -43,16 +43,8 @@ void DMA::LoadState(SaveState const& state) {
     channel_dst.latch.bus = channel_src.latch.bus;
 
     channel_dst.is_fifo_dma = channel_src.is_fifo_dma;
-    channel_dst.enable_event = nullptr;
-
-    u64 enable_event_timestamp = channel_src.enable_event_timestamp;
-
-    if (channel_dst.enable && enable_event_timestamp != ~0ULL) {
-      ScheduleDMAs(1 << i, (int)(enable_event_timestamp - state.timestamp));
-    }
+    channel_dst.event = scheduler.GetEventByUID(channel_src.event_uid);
   }
-
-  SelectNextDMA();
 }
 
 void DMA::CopyState(SaveState& state) {
@@ -85,12 +77,7 @@ void DMA::CopyState(SaveState& state) {
     channel_dst.latch.bus = channel_src.latch.bus;
 
     channel_dst.is_fifo_dma = channel_src.is_fifo_dma;
-
-    if (channel_src.enable_event) {
-      channel_dst.enable_event_timestamp = channel_src.enable_event->timestamp;
-    } else {
-      channel_dst.enable_event_timestamp = ~0ULL;
-    }
+    channel_dst.event_uid = GetEventUID(channel_src.event);
   }
 }
 

--- a/src/nba/src/hw/dma/serialization.cpp
+++ b/src/nba/src/hw/dma/serialization.cpp
@@ -46,6 +46,8 @@ void DMA::LoadState(SaveState const& state) {
 
     channel_dst.event = scheduler.GetEventByUID(channel_src.event_uid);
   }
+
+  SelectNextDMA();
 }
 
 void DMA::CopyState(SaveState& state) {

--- a/src/nba/src/hw/irq/irq.cpp
+++ b/src/nba/src/hw/irq/irq.cpp
@@ -121,12 +121,14 @@ void IRQ::UpdateIRQLine(int event_priority) {
   bool irq_line_new = MasterEnable() && HasServableIRQ();
 
   if (irq_line != irq_line_new) {
-    scheduler.Add(3, [=](int late) {
-      cpu.IRQLine() = irq_line_new;
-    }, event_priority);
+    scheduler.Add(3, Scheduler::EventClass::IRQ_synchronizer_delay, event_priority, (u64)irq_line_new);
 
     irq_line = irq_line_new;
   }
+}
+
+void IRQ::OnIRQDelayPassed(u64 irq_line) {
+  cpu.IRQLine() = (bool)irq_line;
 }
 
 } // namespace nba::core

--- a/src/nba/src/hw/irq/irq.hpp
+++ b/src/nba/src/hw/irq/irq.hpp
@@ -33,6 +33,8 @@ struct IRQ {
   IRQ(arm::ARM7TDMI& cpu, Scheduler& scheduler)
       : cpu(cpu)
       , scheduler(scheduler) {
+    scheduler.Register(Scheduler::EventClass::IRQ_synchronizer_delay, this, &IRQ::OnIRQDelayPassed);
+
     Reset();
   }
 
@@ -62,6 +64,8 @@ private:
   };
 
   void UpdateIRQLine(int event_priority);
+
+  void OnIRQDelayPassed(u64 irq_line);
 
   int reg_ime;
   u16 reg_ie;

--- a/src/nba/src/hw/irq/serialization.cpp
+++ b/src/nba/src/hw/irq/serialization.cpp
@@ -11,11 +11,10 @@
 namespace nba::core {
 
 void IRQ::LoadState(SaveState const& state) {
-  // TODO: restore IRQ delay events:
   reg_ime = state.irq.reg_ime;
   reg_ie = state.irq.reg_ie;
   reg_if = state.irq.reg_if;
-  cpu.IRQLine() = irq_line = MasterEnable() && HasServableIRQ();
+  irq_line = MasterEnable() && HasServableIRQ();
 }
 
 void IRQ::CopyState(SaveState& state) {

--- a/src/nba/src/hw/ppu/ppu.cpp
+++ b/src/nba/src/hw/ppu/ppu.cpp
@@ -30,6 +30,7 @@ PPU::PPU(
 
   scheduler.Register(Scheduler::EventClass::PPU_begin_sprite_fetch, this, &PPU::StupidSpriteEventHandler);
   scheduler.Register(Scheduler::EventClass::PPU_latch_dispcnt, this, &PPU::LatchDISPCNT);
+  scheduler.Register(Scheduler::EventClass::PPU_video_dma, this, &PPU::RequestVideoDMA);
   scheduler.Register(Scheduler::EventClass::PPU_hblank_dma, this, &PPU::RequestHblankDMA);
 
   mmio.dispcnt.ppu = this;
@@ -135,9 +136,7 @@ void PPU::UpdateVideoTransferDMA() {
     if (vcount == 162) {
       dma.StopVideoTransferDMA();
     } else if (vcount >= 2 && vcount < 162) {
-      scheduler.Add(9, [this](int late) {
-        dma.Request(DMA::Occasion::Video);
-      });
+      scheduler.Add(9, Scheduler::EventClass::PPU_video_dma);
     }
   }
 }
@@ -260,6 +259,10 @@ void PPU::OnVblankHblankComplete() {
   UpdateVideoTransferDMA();
 
   InitWindow();
+}
+
+void PPU::RequestVideoDMA() {
+  dma.Request(DMA::Occasion::Video);
 }
 
 void PPU::RequestHblankDMA() {

--- a/src/nba/src/hw/ppu/ppu.cpp
+++ b/src/nba/src/hw/ppu/ppu.cpp
@@ -178,8 +178,6 @@ void PPU::OnHblankComplete() {
   UpdateVideoTransferDMA();
 
   if (vcount == 160) {
-    // ScheduleSubmitScanline();
-
     scheduler.Add(1006, Scheduler::EventClass::PPU_hblank_vblank);
     dma.Request(DMA::Occasion::VBlank);
     dispstat.vblank_flag = 1;
@@ -198,7 +196,6 @@ void PPU::OnHblankComplete() {
     InitMerge();
 
     scheduler.Add(1006, Scheduler::EventClass::PPU_hblank_vdraw);
-    // ScheduleSubmitScanline();
   }
 
   InitWindow();
@@ -260,7 +257,6 @@ void PPU::OnVblankHblankComplete() {
   }
 
   CheckVerticalCounterIRQ();
-  // ScheduleSubmitScanline();
   UpdateVideoTransferDMA();
 
   InitWindow();

--- a/src/nba/src/hw/ppu/ppu.cpp
+++ b/src/nba/src/hw/ppu/ppu.cpp
@@ -29,6 +29,7 @@ PPU::PPU(
   scheduler.Register(Scheduler::EventClass::PPU_hblank_irq_vblank, this, &PPU::OnVblankHblankIRQTest);
 
   scheduler.Register(Scheduler::EventClass::PPU_begin_sprite_fetch, this, &PPU::StupidSpriteEventHandler);
+  scheduler.Register(Scheduler::EventClass::PPU_latch_dispcnt, this, &PPU::LatchDISPCNT);
 
   mmio.dispcnt.ppu = this;
   mmio.dispstat.ppu = this;
@@ -171,9 +172,7 @@ void PPU::OnHblankComplete() {
   DrawWindow();
   DrawMerge();
 
-  scheduler.Add(40, [this](int) {
-    LatchDISPCNT();
-  });
+  scheduler.Add(40, Scheduler::EventClass::PPU_latch_dispcnt);
 
   dispstat.hblank_flag = 0;
   vcount++;
@@ -243,9 +242,7 @@ void PPU::OnVblankHblankComplete() {
   }
 
   if(vcount >= 224) {
-    scheduler.Add(40, [this](int) {
-      LatchDISPCNT();
-    });
+    scheduler.Add(40, Scheduler::EventClass::PPU_latch_dispcnt);
   }
 
   if (vcount == 227) {

--- a/src/nba/src/hw/ppu/ppu.cpp
+++ b/src/nba/src/hw/ppu/ppu.cpp
@@ -20,28 +20,15 @@ PPU::PPU(
     , irq(irq)
     , dma(dma)
     , config(config) {
-  // @todo: get rid of the wrapper jank
-  scheduler.Register(Scheduler::EventClass::PPU_hdraw_vdraw, [this]() {
-    OnHblankComplete();
-  });
-  scheduler.Register(Scheduler::EventClass::PPU_hblank_vdraw, [this]() {
-    OnScanlineComplete();
-  });
-  scheduler.Register(Scheduler::EventClass::PPU_hblank_irq_vdraw, [this]() {
-    OnHblankIRQTest();
-  });
-  scheduler.Register(Scheduler::EventClass::PPU_hdraw_vblank, [this]() {
-    OnVblankHblankComplete();
-  });
-  scheduler.Register(Scheduler::EventClass::PPU_hblank_vblank, [this]() {
-    OnVblankScanlineComplete();
-  });
-  scheduler.Register(Scheduler::EventClass::PPU_hblank_irq_vblank, [this]() {
-    OnVblankHblankIRQTest();
-  });
-  scheduler.Register(Scheduler::EventClass::PPU_begin_sprite_fetch, [this]() {
-    StupidSpriteEventHandler();
-  });
+  scheduler.Register(Scheduler::EventClass::PPU_hdraw_vdraw, this, &PPU::OnHblankComplete);
+  scheduler.Register(Scheduler::EventClass::PPU_hblank_vdraw, this, &PPU::OnScanlineComplete);
+  scheduler.Register(Scheduler::EventClass::PPU_hblank_irq_vdraw, this, &PPU::OnHblankIRQTest);
+
+  scheduler.Register(Scheduler::EventClass::PPU_hdraw_vblank, this, &PPU::OnVblankHblankComplete);
+  scheduler.Register(Scheduler::EventClass::PPU_hblank_vblank, this, &PPU::OnVblankScanlineComplete);
+  scheduler.Register(Scheduler::EventClass::PPU_hblank_irq_vblank, this, &PPU::OnVblankHblankIRQTest);
+
+  scheduler.Register(Scheduler::EventClass::PPU_begin_sprite_fetch, this, &PPU::StupidSpriteEventHandler);
 
   mmio.dispcnt.ppu = this;
   mmio.dispstat.ppu = this;

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -221,12 +221,12 @@ private:
   void CheckVerticalCounterIRQ();
   void UpdateVideoTransferDMA();
 
-  void OnScanlineComplete(int cycles_late);
-  void OnHblankIRQTest(int cycles_late);
-  void OnHblankComplete(int cycles_late);
-  void OnVblankScanlineComplete(int cycles_late);
-  void OnVblankHblankIRQTest(int cycles_late);
-  void OnVblankHblankComplete(int cycles_late);
+  void OnScanlineComplete();
+  void OnHblankIRQTest();
+  void OnHblankComplete();
+  void OnVblankScanlineComplete();
+  void OnVblankHblankIRQTest();
+  void OnVblankHblankComplete();
 
   struct Background {
     u64 timestamp_init = 0;
@@ -332,7 +332,7 @@ private:
   void DrawSpriteImpl(int cycles);
   void DrawSpriteFetchOAM(uint cycle);
   void DrawSpriteFetchVRAM(uint cycle);
-  void StupidSpriteEventHandler(int cycles);
+  void StupidSpriteEventHandler();
 
   struct Window {
     u64 timestamp_last_sync;

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -229,6 +229,7 @@ private:
   void OnVblankHblankComplete();
   void StupidSpriteEventHandler();
 
+  void RequestVideoDMA();
   void RequestHblankDMA();
 
   struct Background {

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -227,6 +227,7 @@ private:
   void OnVblankScanlineComplete();
   void OnVblankHblankIRQTest();
   void OnVblankHblankComplete();
+  void StupidSpriteEventHandler();
 
   struct Background {
     u64 timestamp_init = 0;
@@ -332,7 +333,6 @@ private:
   void DrawSpriteImpl(int cycles);
   void DrawSpriteFetchOAM(uint cycle);
   void DrawSpriteFetchVRAM(uint cycle);
-  void StupidSpriteEventHandler();
 
   struct Window {
     u64 timestamp_last_sync;

--- a/src/nba/src/hw/ppu/ppu.hpp
+++ b/src/nba/src/hw/ppu/ppu.hpp
@@ -229,6 +229,8 @@ private:
   void OnVblankHblankComplete();
   void StupidSpriteEventHandler();
 
+  void RequestHblankDMA();
+
   struct Background {
     u64 timestamp_init = 0;
     u64 timestamp_last_sync = 0;

--- a/src/nba/src/hw/ppu/serialization.cpp
+++ b/src/nba/src/hw/ppu/serialization.cpp
@@ -65,31 +65,6 @@ void PPU::LoadState(SaveState const& state) {
   std::memcpy(oam,  state.bus.memory.oam,  0x400);
   std::memcpy(vram, state.bus.memory.vram, 0x18000);
 
-  // /**
-  //  * NOTE: we cannot use DISPCNT.vblank_flag here, because the flag
-  //  * will be unset during the last scanline.
-  //  */
-  // bool vblank = mmio.vcount >= 160;
-  // auto cycles = state.timestamp % 1232U;
-  // Scheduler::EventMethod<PPU> event_fn;
-
-  // /* Recreate the PPU state machine event.
-  //  * Note that the PPU supposedly starts in H-blank (see PPU::Reset).
-  //  * @todo: what if the event is scheduled with zero delay? Will this break?
-  //  */
-  // scheduler.Add((266 - cycles + 1232) % 1232, this, &PPU::StupidSpriteEventHandler);
-  // if (cycles <= 2) {
-  //   event_fn = vblank ? &PPU::OnVblankHblankIRQTest : &PPU::OnHblankIRQTest;
-  //   cycles = 2 - cycles;
-  // } else if (cycles <= 224) {
-  //   event_fn = vblank ? &PPU::OnVblankHblankComplete : &PPU::OnHblankComplete;
-  //   cycles = 224 - cycles;
-  // } else {
-  //   event_fn = vblank ? &PPU::OnVblankScanlineComplete : &PPU::OnScanlineComplete;
-  //   cycles = 1232 - cycles;
-  // }
-  // scheduler.Add(cycles, this, event_fn);
-
   dma3_video_transfer_running = ss_ppu.dma3_video_transfer_running;
 }
 

--- a/src/nba/src/hw/ppu/serialization.cpp
+++ b/src/nba/src/hw/ppu/serialization.cpp
@@ -65,30 +65,30 @@ void PPU::LoadState(SaveState const& state) {
   std::memcpy(oam,  state.bus.memory.oam,  0x400);
   std::memcpy(vram, state.bus.memory.vram, 0x18000);
 
-  /**
-   * NOTE: we cannot use DISPCNT.vblank_flag here, because the flag
-   * will be unset during the last scanline.
-   */
-  bool vblank = mmio.vcount >= 160;
-  auto cycles = state.timestamp % 1232U;
-  Scheduler::EventMethod<PPU> event_fn;
+  // /**
+  //  * NOTE: we cannot use DISPCNT.vblank_flag here, because the flag
+  //  * will be unset during the last scanline.
+  //  */
+  // bool vblank = mmio.vcount >= 160;
+  // auto cycles = state.timestamp % 1232U;
+  // Scheduler::EventMethod<PPU> event_fn;
 
-  /* Recreate the PPU state machine event.
-   * Note that the PPU supposedly starts in H-blank (see PPU::Reset).
-   * @todo: what if the event is scheduled with zero delay? Will this break?
-   */
-  scheduler.Add((266 - cycles + 1232) % 1232, this, &PPU::StupidSpriteEventHandler);
-  if (cycles <= 2) {
-    event_fn = vblank ? &PPU::OnVblankHblankIRQTest : &PPU::OnHblankIRQTest;
-    cycles = 2 - cycles;
-  } else if (cycles <= 224) {
-    event_fn = vblank ? &PPU::OnVblankHblankComplete : &PPU::OnHblankComplete;
-    cycles = 224 - cycles;
-  } else {
-    event_fn = vblank ? &PPU::OnVblankScanlineComplete : &PPU::OnScanlineComplete;
-    cycles = 1232 - cycles;
-  }
-  scheduler.Add(cycles, this, event_fn);
+  // /* Recreate the PPU state machine event.
+  //  * Note that the PPU supposedly starts in H-blank (see PPU::Reset).
+  //  * @todo: what if the event is scheduled with zero delay? Will this break?
+  //  */
+  // scheduler.Add((266 - cycles + 1232) % 1232, this, &PPU::StupidSpriteEventHandler);
+  // if (cycles <= 2) {
+  //   event_fn = vblank ? &PPU::OnVblankHblankIRQTest : &PPU::OnHblankIRQTest;
+  //   cycles = 2 - cycles;
+  // } else if (cycles <= 224) {
+  //   event_fn = vblank ? &PPU::OnVblankHblankComplete : &PPU::OnHblankComplete;
+  //   cycles = 224 - cycles;
+  // } else {
+  //   event_fn = vblank ? &PPU::OnVblankScanlineComplete : &PPU::OnScanlineComplete;
+  //   cycles = 1232 - cycles;
+  // }
+  // scheduler.Add(cycles, this, event_fn);
 
   dma3_video_transfer_running = ss_ppu.dma3_video_transfer_running;
 }

--- a/src/nba/src/hw/timer/serialization.cpp
+++ b/src/nba/src/hw/timer/serialization.cpp
@@ -32,12 +32,7 @@ void Timer::LoadState(SaveState const& state) {
     channels[i].mask = g_ticks_mask[channels[i].control.frequency];
 
     channels[i].running = false;
-    channels[i].event_overflow = nullptr;
-
-    if (channels[i].control.enable && !channels[i].control.cascade) {
-      // TODO: take care of the one cycle startup-delay:
-      StartChannel(channels[i], state.timestamp & channels[i].mask);
-    }
+    channels[i].event_overflow = scheduler.GetEventByUID(state.timer[i].event_uid);
 
     if (pending_reload != reload) {
       WriteReload(channels[i], pending_reload);
@@ -58,6 +53,7 @@ void Timer::CopyState(SaveState& state) {
     state.timer[i].control = ReadControl(channels[i]);
     state.timer[i].pending.reload = channels[i].pending.reload;
     state.timer[i].pending.control = channels[i].pending.control;
+    state.timer[i].event_uid = GetEventUID(channels[i].event_overflow);
   }
 }
 

--- a/src/nba/src/hw/timer/serialization.cpp
+++ b/src/nba/src/hw/timer/serialization.cpp
@@ -17,8 +17,6 @@ void Timer::LoadState(SaveState const& state) {
   for (int i = 0; i < 4; i++) {
     u16 reload  = state.timer[i].reload;
     u16 control = state.timer[i].control;
-    u16 pending_reload  = state.timer[i].pending.reload;
-    u16 pending_control = state.timer[i].pending.control;
 
     channels[i].reload  = reload;
     channels[i].counter = state.timer[i].counter;
@@ -34,13 +32,8 @@ void Timer::LoadState(SaveState const& state) {
     channels[i].running = false;
     channels[i].event_overflow = scheduler.GetEventByUID(state.timer[i].event_uid);
 
-    if (pending_reload != reload) {
-      WriteReload(channels[i], pending_reload);
-    }
-
-    if (pending_control != control) {
-      WriteControl(channels[i], pending_control);
-    }
+    channels[i].pending.reload = state.timer[i].pending.reload;
+    channels[i].pending.control = state.timer[i].pending.control;
   }
 
   RecalculateSampleRates();

--- a/src/nba/src/hw/timer/timer.cpp
+++ b/src/nba/src/hw/timer/timer.cpp
@@ -76,11 +76,11 @@ void Timer::WriteByte(int chan_id, int offset, u8 value) {
 
   switch (offset) {
     case REG_TMXCNT_L | 0: {
-      WriteReload(channel, (channel.reload & 0xFF00) | (value << 0));
+      WriteReload(channel, (channel.pending.reload & 0xFF00) | (value << 0));
       break;
     }
     case REG_TMXCNT_L | 1: {
-      WriteReload(channel, (channel.reload & 0x00FF) | (value << 8));
+      WriteReload(channel, (channel.pending.reload & 0x00FF) | (value << 8));
       break;
     }
     case REG_TMXCNT_H: {
@@ -221,7 +221,7 @@ void Timer::StartChannel(Channel& channel, int cycle_offset) {
 
   channel.running = true;
   channel.timestamp_started = scheduler.GetTimestampNow() - cycle_offset;
-  channel.event_overflow = scheduler.Add(cycles, Scheduler::EventClass::TM_overflow);
+  channel.event_overflow = scheduler.Add(cycles, Scheduler::EventClass::TM_overflow, 0, channel.id);
 }
 
 void Timer::StopChannel(Channel& channel) {

--- a/src/nba/src/hw/timer/timer.hpp
+++ b/src/nba/src/hw/timer/timer.hpp
@@ -18,12 +18,7 @@
 namespace nba::core {
 
 struct Timer {
-  Timer(Scheduler& scheduler, IRQ& irq, APU& apu)
-      : scheduler(scheduler)
-      , irq(irq)
-      , apu(apu) {
-    Reset();
-  }
+  Timer(Scheduler& scheduler, IRQ& irq, APU& apu);
 
   void Reset();
   auto ReadByte(int chan_id, int offset) -> u8;
@@ -65,7 +60,6 @@ private:
     int samplerate;
     u64 timestamp_started;
     Scheduler::Event* event_overflow = nullptr;
-    std::function<void(int)> fn_overflow;
   } channels[4];
 
   Scheduler& scheduler;
@@ -80,9 +74,10 @@ private:
 
   void RecalculateSampleRates();
   auto GetCounterDeltaSinceLastUpdate(Channel const& channel) -> u32;
-  void StartChannel(Channel& channel, int cycles_late);
+  void StartChannel(Channel& channel, int cycle_offset);
   void StopChannel(Channel& channel);
-  void OnOverflow(Channel& channel);
+  void ReloadCascadeAndRequestIRQ(Channel& channel);
+  void OnOverflow(u64 chan_id);
 };
 
 } // namespace nba::core

--- a/src/nba/src/hw/timer/timer.hpp
+++ b/src/nba/src/hw/timer/timer.hpp
@@ -72,6 +72,9 @@ private:
   auto ReadControl(Channel const& channel) -> u16;
   void WriteControl(Channel& channel, u16 value);
 
+  void OnReloadWritten(u64 chan_id);
+  void OnControlWritten(u64 chan_id);
+
   void RecalculateSampleRates();
   auto GetCounterDeltaSinceLastUpdate(Channel const& channel) -> u32;
   void StartChannel(Channel& channel, int cycle_offset);

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -37,6 +37,7 @@ struct Scheduler {
     PPU_hblank_vblank,
     PPU_hblank_irq_vblank,
     PPU_begin_sprite_fetch,
+    PPU_latch_dispcnt,
 
     // APU
     APU_mixer,

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -29,6 +29,9 @@ struct Scheduler {
   enum class EventClass : u16 {
     Unknown,
 
+    // ARM
+    ARM_ldm_usermode_conflict,
+
     // PPU
     PPU_hdraw_vdraw,
     PPU_hblank_vdraw,

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -41,6 +41,10 @@ struct Scheduler {
     // APU
     APU_mixer,
     APU_sequencer,
+    APU_PSG1_generate,
+    APU_PSG2_generate,
+    APU_PSG3_generate,
+    APU_PSG4_generate,
 
     Count
   };
@@ -48,6 +52,9 @@ struct Scheduler {
   struct Event {
     std::function<void(int)> callback;
     u64 timestamp; 
+
+    u64 UID() const { return uid; }
+  
   private:
     friend class Scheduler;
     int handle;
@@ -81,7 +88,7 @@ struct Scheduler {
   void Reset() {
     heap_size = 0;
     timestamp_now = 0;
-    next_uid = 0;
+    next_uid = 1;
     Add(std::numeric_limits<u64>::max(), [](int) {
       Assert(false, "Scheduler: reached end of the event queue.");
     });
@@ -305,5 +312,9 @@ private:
 
   std::function<void(u64)> callbacks[(int)EventClass::Count];
 };
+
+inline u64 GetEventUID(Scheduler::Event* event) {
+  return event ? event->UID() : 0;
+}
 
 } // namespace nba::core

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -46,6 +46,9 @@ struct Scheduler {
     APU_PSG3_generate,
     APU_PSG4_generate,
 
+    // IRQ controller
+    IRQ_synchronizer_delay,
+
     Count
   };
 

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -203,10 +203,11 @@ struct Scheduler {
       EventClass event_class = (EventClass)event.event_class;
 
       if(event_class != EventClass::Unknown) {
-        Add(timestamp - state.timestamp, event_class, priority);
+        Add(timestamp - state.timestamp, event_class, priority)->uid = event.uid;
       }
     }
 
+    // This must happen after deserializing all events, because calling Add() modifies `next_uid`.
     next_uid = ss_scheduler.next_uid;
   }
 
@@ -216,7 +217,7 @@ struct Scheduler {
     for(int i = 0; i < heap_size; i++) {
       auto event = heap[i];
 
-      ss_scheduler.events[i] = { event->key, (u16)event->event_class };
+      ss_scheduler.events[i] = { event->key, event->uid, (u16)event->event_class };
     }
 
     ss_scheduler.event_count = heap_size;

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -37,6 +37,7 @@ struct Scheduler {
     PPU_hblank_vblank,
     PPU_hblank_irq_vblank,
     PPU_begin_sprite_fetch,
+    PPU_video_dma,
     PPU_hblank_dma,
     PPU_latch_dispcnt,
 

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -51,6 +51,8 @@ struct Scheduler {
 
     // Timers
     TM_overflow,
+    TM_write_reload,
+    TM_write_control,
 
     Count
   };

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -37,6 +37,7 @@ struct Scheduler {
     PPU_hblank_vblank,
     PPU_hblank_irq_vblank,
     PPU_begin_sprite_fetch,
+    PPU_hblank_dma,
     PPU_latch_dispcnt,
 
     // APU

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -54,6 +54,9 @@ struct Scheduler {
     TM_write_reload,
     TM_write_control,
 
+    // DMA
+    DMA_activated,
+
     Count
   };
 

--- a/src/nba/src/scheduler.hpp
+++ b/src/nba/src/scheduler.hpp
@@ -49,6 +49,9 @@ struct Scheduler {
     // IRQ controller
     IRQ_synchronizer_delay,
 
+    // Timers
+    TM_overflow,
+
     Count
   };
 

--- a/src/nba/src/serialization.cpp
+++ b/src/nba/src/serialization.cpp
@@ -13,6 +13,7 @@ void Core::LoadState(SaveState const& state) {
   scheduler.Reset();
   scheduler.SetTimestampNow(state.timestamp);
 
+  scheduler.LoadState(state);
   cpu.LoadState(state);
   bus.LoadState(state);
   irq.LoadState(state);
@@ -28,6 +29,7 @@ void Core::CopyState(SaveState& state) {
   state.version = SaveState::kCurrentVersion;
   state.timestamp = scheduler.GetTimestampNow();
 
+  scheduler.CopyState(state);
   cpu.CopyState(state);
   bus.CopyState(state);
   irq.CopyState(state);


### PR DESCRIPTION
Previously we were not able to save and restore scheduler events when saving/loading a save state.
So instead we opted to try recreate all events from other state when loading save states.
This worked somewhat fine in most cases but isn't ideal and doesn't scale well to scheduling more fine grained/nuanced events such as 'operation Y happens with 1 cycle delay after operation X'.

This PR allows us to finally (de)serialize all events by tagging them with an event class/type instead of storing the raw callbacks. 