### PR TITLE
Rendering loop rewrite

### DIFF
--- a/src/platform/core/include/platform/device/ogl_video_device.hpp
+++ b/src/platform/core/include/platform/device/ogl_video_device.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <array>
 #include <nba/device/video_device.hpp>
 #include <GL/glew.h>
 #include <platform/config.hpp>
@@ -49,9 +50,9 @@ private:
   GLuint quad_vao;
   GLuint quad_vbo;
   GLuint fbo;
-  GLuint texture[4];
+  std::array<GLuint, 4> textures = {};
   std::vector<GLuint> programs;
-  GLenum texture_filter = GL_NEAREST;
+  GLint texture_filter = GL_NEAREST;
   bool texture_filter_invalid = false;
 
   std::shared_ptr<PlatformConfig> config;

--- a/src/platform/core/include/platform/device/ogl_video_device.hpp
+++ b/src/platform/core/include/platform/device/ogl_video_device.hpp
@@ -30,6 +30,7 @@ struct OGLVideoDevice : VideoDevice {
 private:
   void UpdateTextures();
   void CreateShaderPrograms();
+  void UpdateShaderUniforms();
   void ReleaseShaderPrograms();
 
   auto CompileShader(

--- a/src/platform/core/include/platform/device/ogl_video_device.hpp
+++ b/src/platform/core/include/platform/device/ogl_video_device.hpp
@@ -43,6 +43,19 @@ private:
     char const* fragment_src
   ) -> std::pair<bool, GLuint>;
 
+  static constexpr size_t input_index       = 0;
+  static constexpr size_t output_index      = 1;
+  static constexpr size_t history_index     = 2;
+  static constexpr size_t xbrz_output_index = 3;
+
+  struct ShaderPass {
+    GLuint program = 0;
+    struct {
+      std::vector<GLuint> inputs = {input_index};
+      GLuint output = output_index;
+    } textures = {};
+  };
+
   int view_x = 0;
   int view_y = 0;
   int view_width  = 1;
@@ -52,8 +65,8 @@ private:
   GLuint quad_vao;
   GLuint quad_vbo;
   GLuint fbo;
-  std::array<GLuint, 4> textures = {};
-  std::vector<GLuint> programs;
+  std::array<GLuint, 4> textures        = {};
+  std::vector<ShaderPass> shader_passes = {};
   GLint texture_filter = GL_NEAREST;
 
   std::shared_ptr<PlatformConfig> config;

--- a/src/platform/core/include/platform/device/ogl_video_device.hpp
+++ b/src/platform/core/include/platform/device/ogl_video_device.hpp
@@ -28,6 +28,7 @@ struct OGLVideoDevice : VideoDevice {
   void ReloadConfig();
 
 private:
+  void UpdateTextures();
   void CreateShaderPrograms();
   void ReleaseShaderPrograms();
 
@@ -53,7 +54,6 @@ private:
   std::array<GLuint, 4> textures = {};
   std::vector<GLuint> programs;
   GLint texture_filter = GL_NEAREST;
-  bool texture_filter_invalid = false;
 
   std::shared_ptr<PlatformConfig> config;
 };

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -237,21 +237,6 @@ void OGLVideoDevice::SetViewport(int x, int y, int width, int height) {
   view_width  = width;
   view_height = height;
 
-  for(int i = 0; i < 3; i++) {
-    glBindTexture(GL_TEXTURE_2D, textures[i]);
-    glTexImage2D(
-      GL_TEXTURE_2D,
-      0,
-      GL_RGBA,
-      view_width,
-      view_height,
-      0,
-      GL_BGRA,
-      GL_UNSIGNED_BYTE,
-      nullptr
-    );
-  }
-
   UpdateShaderUniforms();
 }
 
@@ -278,7 +263,7 @@ void OGLVideoDevice::Draw(u32* buffer) {
 
   auto program_count = programs.size();
 
-  glViewport(0, 0, view_width, view_height);
+  glViewport(0, 0, gba_screen_width, gba_screen_height);
   glBindVertexArray(quad_vao);
 
   if(program_count <= 2) {

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -250,8 +250,8 @@ void OGLVideoDevice::Draw(u32* buffer) {
   // Update and bind LCD screen texture
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, textures[3]);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, gba_screen_width, gba_screen_height,
-               0, GL_BGRA, GL_UNSIGNED_BYTE, buffer);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, gba_screen_width, gba_screen_height,
+                  GL_BGRA, GL_UNSIGNED_BYTE, buffer);
 
   // Bind LCD history map
   glActiveTexture(GL_TEXTURE1);

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -58,7 +58,6 @@ void OGLVideoDevice::Initialize() {
   glEnableVertexAttribArray(1);
 
   // Create three textures and a framebuffer for postprocessing.
-  glEnable(GL_TEXTURE_2D);
   glGenFramebuffers(1, &fbo);
   glGenTextures(4, texture);
   for(int i = 0; i < 4; i++) {

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -22,6 +22,9 @@ using Video = nba::PlatformConfig::Video;
 
 namespace nba {
 
+static constexpr int gba_screen_width  = 240;
+static constexpr int gba_screen_height = 160;
+
 static const float kQuadVertices[] = {
 // position | UV coord
   -1,  1,     0, 1,
@@ -243,9 +246,8 @@ void OGLVideoDevice::Draw(u32* buffer) {
   // Update and bind LCD screen texture
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, texture[3]);
-  glTexImage2D(
-    GL_TEXTURE_2D, 0, GL_RGBA, 240, 160, 0, GL_BGRA, GL_UNSIGNED_BYTE, buffer
-  );
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, gba_screen_width, gba_screen_height,
+               0, GL_BGRA, GL_UNSIGNED_BYTE, buffer);
   if(texture_filter_invalid) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, texture_filter);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texture_filter);

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -5,6 +5,7 @@
  * Refer to the included LICENSE file.
  */
 
+#include <array>
 #include <filesystem>
 #include <fmt/format.h>
 #include <fstream>
@@ -25,14 +26,12 @@ namespace nba {
 static constexpr int gba_screen_width  = 240;
 static constexpr int gba_screen_height = 160;
 
-static const float kQuadVertices[] = {
+static constexpr std::array<GLfloat, 4 * 4> kQuadVertices = {
 // position | UV coord
-  -1,  1,     0, 1,
-   1,  1,     1, 1,
-   1, -1,     1, 0,
-   1, -1,     1, 0,
   -1, -1,     0, 0,
-  -1,  1,     0, 1
+   1, -1,     1, 0,
+  -1,  1,     0, 1,
+   1,  1,     1, 1
 };
 
 OGLVideoDevice::OGLVideoDevice(std::shared_ptr<PlatformConfig> config) : config(config) {
@@ -54,7 +53,7 @@ void OGLVideoDevice::Initialize() {
   glGenBuffers(1, &quad_vbo);
   glBindVertexArray(quad_vao);
   glBindBuffer(GL_ARRAY_BUFFER, quad_vbo);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(kQuadVertices), kQuadVertices, GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(kQuadVertices), kQuadVertices.data(), GL_STATIC_DRAW);
   glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
   glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
   glEnableVertexAttribArray(0);
@@ -282,7 +281,7 @@ void OGLVideoDevice::Draw(u32* buffer) {
       glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture[target], 0);
     }
 
-    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
     // Output of the current pass is the input for the next pass.
     glActiveTexture(GL_TEXTURE0);

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -146,21 +146,25 @@ void OGLVideoDevice::CreateShaderPrograms() {
     programs.push_back(program);
   }
 
+  UpdateShaderUniforms();
+}
+
+void OGLVideoDevice::UpdateShaderUniforms() {
   // Set constant shader uniforms.
-  for(auto program : programs) {
+  for(const auto program : programs) {
     glUseProgram(program);
 
-    auto screen_map = glGetUniformLocation(program, "u_screen_map");
+    const auto screen_map = glGetUniformLocation(program, "u_screen_map");
     if(screen_map != -1) {
       glUniform1i(screen_map, 0);
     }
 
-    auto history_map = glGetUniformLocation(program, "u_history_map");
+    const auto history_map = glGetUniformLocation(program, "u_history_map");
     if(history_map != -1) {
       glUniform1i(history_map, 1);
     }
 
-    auto source_map = glGetUniformLocation(program, "u_source_map");
+    const auto source_map = glGetUniformLocation(program, "u_source_map");
     if(source_map != -1) {
       glUniform1i(source_map, 2);
     }

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -168,6 +168,11 @@ void OGLVideoDevice::UpdateShaderUniforms() {
     if(source_map != -1) {
       glUniform1i(source_map, 2);
     }
+
+    const auto output_size = glGetUniformLocation(program, "u_output_size");
+    if(output_size != -1) {
+      glUniform2f(output_size, view_width, view_height);
+    }
   }
 }
 
@@ -246,6 +251,8 @@ void OGLVideoDevice::SetViewport(int x, int y, int width, int height) {
       nullptr
     );
   }
+
+  UpdateShaderUniforms();
 }
 
 void OGLVideoDevice::SetDefaultFBO(GLuint fbo) {

--- a/src/platform/core/src/device/ogl_video_device.cpp
+++ b/src/platform/core/src/device/ogl_video_device.cpp
@@ -154,9 +154,9 @@ void OGLVideoDevice::UpdateShaderUniforms() {
   for(const auto program : programs) {
     glUseProgram(program);
 
-    const auto screen_map = glGetUniformLocation(program, "u_screen_map");
-    if(screen_map != -1) {
-      glUniform1i(screen_map, 0);
+    const auto input_map = glGetUniformLocation(program, "u_input_map");
+    if(input_map != -1) {
+      glUniform1i(input_map, 0);
     }
 
     const auto history_map = glGetUniformLocation(program, "u_history_map");

--- a/src/platform/core/src/device/shader/color_agb.glsl.hpp
+++ b/src/platform/core/src/device/shader/color_agb.glsl.hpp
@@ -42,10 +42,10 @@ constexpr auto color_agb_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_screen_map;
+  uniform sampler2D u_input_map;
 
   void main() {
-    vec4 screen = pow(texture(u_screen_map, v_uv), vec4(target_gamma + darken_screen)).rgba;
+    vec4 screen = pow(texture(u_input_map, v_uv), vec4(target_gamma + darken_screen)).rgba;
     vec4 avglum = vec4(0.5);
     screen = mix(screen, avglum, (1.0 - contrast));
      

--- a/src/platform/core/src/device/shader/color_higan.glsl.hpp
+++ b/src/platform/core/src/device/shader/color_higan.glsl.hpp
@@ -12,10 +12,10 @@ constexpr auto color_higan_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_screen_map;
+  uniform sampler2D u_input_map;
 
   void main() {
-    vec4 color = texture(u_screen_map, v_uv);
+    vec4 color = texture(u_input_map, v_uv);
 
     color.rgb = pow(color.rgb, vec3(4.0));
 

--- a/src/platform/core/src/device/shader/common.glsl.hpp
+++ b/src/platform/core/src/device/shader/common.glsl.hpp
@@ -20,3 +20,17 @@ constexpr auto common_vert = R"(
     gl_Position = vec4(position, 0.0, 1.0);
   }
 )";
+
+constexpr auto common_flip_vert = R"(
+  #version 330 core
+
+  layout(location = 0) in vec2 position;
+  layout(location = 1) in vec2 uv;
+
+  out vec2 v_uv;
+
+  void main() {
+    v_uv = vec2(uv.x, 1.0 - uv.y);
+    gl_Position = vec4(position, 0.0, 1.0);
+  }
+)";

--- a/src/platform/core/src/device/shader/lcd_ghosting.glsl.hpp
+++ b/src/platform/core/src/device/shader/lcd_ghosting.glsl.hpp
@@ -18,11 +18,11 @@ constexpr auto lcd_ghosting_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_screen_map;
+  uniform sampler2D u_input_map;
   uniform sampler2D u_history_map;
 
   void main() {
-    vec4 color_a = texture(u_screen_map, v_uv);
+    vec4 color_a = texture(u_input_map, v_uv);
     vec4 color_b = texture(u_history_map, v_uv);
     frag_color = mix(color_a, color_b, 0.5);
   }

--- a/src/platform/core/src/device/shader/output.glsl.hpp
+++ b/src/platform/core/src/device/shader/output.glsl.hpp
@@ -9,7 +9,7 @@
 
 #include "device/shader/common.glsl.hpp"
 
-constexpr auto output_vert = common_vert;
+constexpr auto output_vert = common_flip_vert;
 
 constexpr auto output_frag = R"(
   #version 330 core
@@ -21,6 +21,6 @@ constexpr auto output_frag = R"(
   uniform sampler2D u_input_map;
 
   void main() {
-    frag_color = texture(u_input_map, vec2(v_uv.x, 1.0 - v_uv.y));
+    frag_color = texture(u_input_map, v_uv);
   }
 )";

--- a/src/platform/core/src/device/shader/output.glsl.hpp
+++ b/src/platform/core/src/device/shader/output.glsl.hpp
@@ -18,9 +18,9 @@ constexpr auto output_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_screen_map;
+  uniform sampler2D u_input_map;
 
   void main() {
-    frag_color = texture(u_screen_map, vec2(v_uv.x, 1.0 - v_uv.y));
+    frag_color = texture(u_input_map, vec2(v_uv.x, 1.0 - v_uv.y));
   }
 )";

--- a/src/platform/core/src/device/shader/xbrz.glsl.hpp
+++ b/src/platform/core/src/device/shader/xbrz.glsl.hpp
@@ -268,24 +268,7 @@ frag_color /= 255.0;
 }
 )";
 
-constexpr auto xbrz1_vert = R"(
-  #version 330 core
-
-  layout(location = 0) in vec2 position;
-  layout(location = 1) in vec2 uv;
-
-  out vec2 v_uv;
-  out vec4 u_screen_size;
-
-  uniform sampler2D u_screen_map;
-
-  void main() {
-    v_uv = uv;
-    u_screen_size.xy = textureSize(u_screen_map, 0);
-    u_screen_size.zw = 1.0 / textureSize(u_screen_map, 0);
-    gl_Position = vec4(position, 0.0, 1.0);
-  }
-)";
+constexpr auto xbrz1_vert = common_vert;
 
 constexpr auto xbrz1_frag = R"(
   #version 330 core
@@ -293,10 +276,10 @@ constexpr auto xbrz1_frag = R"(
   layout(location = 0) out vec4 frag_color;
 
   in vec2 v_uv;
-  in vec4 u_screen_size;
 
   uniform sampler2D u_screen_map; // info texture
   uniform sampler2D u_source_map; // LCD texture
+  uniform vec2 u_output_size;
 
   #define u_source_size vec4(240.0, 160.0, 1.0/240.0, 1.0/160.0)
 
@@ -350,7 +333,7 @@ constexpr auto xbrz1_frag = R"(
     //                      D|E|F
     //                      -|H|-
 
-    vec2 scale = u_screen_size.xy * u_source_size.zw;
+    vec2 scale = u_output_size.xy * u_source_size.zw;
     vec2 pos = fract(v_uv * u_source_size.xy) - vec2(0.5, 0.5);
     vec2 coord = v_uv - pos * u_source_size.zw;
 

--- a/src/platform/core/src/device/shader/xbrz.glsl.hpp
+++ b/src/platform/core/src/device/shader/xbrz.glsl.hpp
@@ -52,9 +52,9 @@ constexpr auto xbrz0_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_source_map;
+  uniform sampler2D u_input_map;
 
-  #define u_source_size vec4(240.0, 160.0, 1.0/240.0, 1.0/160.0)
+  #define u_input_size vec4(240.0, 160.0, 1.0/240.0, 1.0/160.0)
 
   #define BLEND_NONE 0
   #define BLEND_NORMAL 1
@@ -98,7 +98,7 @@ constexpr auto xbrz0_frag = R"(
   #define eq(a,b)  (a == b)
   #define neq(a,b) (a != b)
 
-  #define P(x,y) texture(u_source_map, coord + u_source_size.zw * vec2(x, y)).rgb
+  #define P(x,y) texture(u_input_map, coord + u_input_size.zw * vec2(x, y)).rgb
 
 void main() {
   //---------------------------------------
@@ -108,8 +108,8 @@ void main() {
   //                       x|G|H|I|x
   //                       -|x|x|x|-
 
-  vec2 pos = fract(v_uv * u_source_size.xy) - vec2(0.5, 0.5);
-  vec2 coord = v_uv - pos * u_source_size.zw;
+  vec2 pos = fract(v_uv * u_input_size.xy) - vec2(0.5, 0.5);
+  vec2 coord = v_uv - pos * u_input_size.zw;
 
   vec3 A = P(-1,-1);
   vec3 B = P( 0,-1);
@@ -268,7 +268,7 @@ frag_color /= 255.0;
 }
 )";
 
-constexpr auto xbrz1_vert = common_vert;
+constexpr auto xbrz1_vert = common_flip_vert;
 
 constexpr auto xbrz1_frag = R"(
   #version 330 core
@@ -277,11 +277,11 @@ constexpr auto xbrz1_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_input_map; // info texture
-  uniform sampler2D u_source_map; // LCD texture
+  uniform sampler2D u_input_map; // LCD texture
+  uniform sampler2D u_info_map; // info texture
   uniform vec2 u_output_size;
 
-  #define u_source_size vec4(240.0, 160.0, 1.0/240.0, 1.0/160.0)
+  #define u_input_size vec4(240.0, 160.0, 1.0/240.0, 1.0/160.0)
 
   #define BLEND_NONE 0
   #define BLEND_NORMAL 1
@@ -325,7 +325,7 @@ constexpr auto xbrz1_frag = R"(
   #define eq(a,b)  (a == b)
   #define neq(a,b) (a != b)
 
-  #define P(x,y) texture(u_source_map, coord + u_source_size.zw * vec2(x, y)).rgb
+  #define P(x,y) texture(u_input_map, coord + u_input_size.zw * vec2(x, y)).rgb
 
   void main() {
    //---------------------------------------
@@ -333,9 +333,9 @@ constexpr auto xbrz1_frag = R"(
     //                      D|E|F
     //                      -|H|-
 
-    vec2 scale = u_output_size.xy * u_source_size.zw;
-    vec2 pos = fract(v_uv * u_source_size.xy) - vec2(0.5, 0.5);
-    vec2 coord = v_uv - pos * u_source_size.zw;
+    vec2 scale = u_output_size.xy * u_input_size.zw;
+    vec2 pos = fract(v_uv * u_input_size.xy) - vec2(0.5, 0.5);
+    vec2 coord = v_uv - pos * u_input_size.zw;
 
     vec3 B = P( 0,-1);
     vec3 D = P(-1, 0);
@@ -343,7 +343,7 @@ constexpr auto xbrz1_frag = R"(
     vec3 F = P( 1, 0);
     vec3 H = P( 0, 1);
 
-    vec4 info = floor(texture(u_input_map, coord) * 255.0 + 0.5);
+    vec4 info = floor(texture(u_info_map, coord) * 255.0 + 0.5);
 
     // info Mapping: x|y|
     //               w|z|

--- a/src/platform/core/src/device/shader/xbrz.glsl.hpp
+++ b/src/platform/core/src/device/shader/xbrz.glsl.hpp
@@ -277,7 +277,7 @@ constexpr auto xbrz1_frag = R"(
 
   in vec2 v_uv;
 
-  uniform sampler2D u_screen_map; // info texture
+  uniform sampler2D u_input_map; // info texture
   uniform sampler2D u_source_map; // LCD texture
   uniform vec2 u_output_size;
 
@@ -343,7 +343,7 @@ constexpr auto xbrz1_frag = R"(
     vec3 F = P( 1, 0);
     vec3 H = P( 0, 1);
 
-    vec4 info = floor(texture(u_screen_map, coord) * 255.0 + 0.5);
+    vec4 info = floor(texture(u_input_map, coord) * 255.0 + 0.5);
 
     // info Mapping: x|y|
     //               w|z|


### PR DESCRIPTION
Tested on Intel Core i5-7400 with integrated Intel HD Graphics 630 (max. clock is 1000 MHz), DDR4 2400 MHz, Mesa 23.2.1. Enabled xBRZ scaler, GBA colour correction, and LCD ghosting effect, the window size was set to 6x. Metrics reported by `intel_gpu_top` utility.

The current renderer results in 60+% utilization, at ~600 MHz GPU clock. This PR reduces that to 45-50% utilization, at 230±30 MHz GPU clock. May be a bit lower in fullscreen mode, possibly results will vary depending on showed content.

The output of xBRZ shader differs slightly due to being moved to the end of the chain, but it's barely noticeable. When both xBRZ and LCD ghosting are enabled, the former is placed before the latter.

Shout if you'd like to see commit messages changed, code style adjusted, and more comments added. I intentionally omitted whitespace and line ending changes, for the sake of simpler review process. Can introduce them in a separate commit.

Extracted from and is a prerequisite to #332.
