### PR TITLE
Log: Switch to fmt::text_style for coloring

### DIFF
--- a/src/nba/include/nba/log.hpp
+++ b/src/nba/include/nba/log.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <array>
+#include <fmt/color.h>
 #include <fmt/format.h>
 #include <string_view>
 #include <utility>
@@ -38,16 +39,35 @@ namespace detail {
 template<Level level, typename... Args>
 inline void Log(std::string_view format, Args&&... args) {
   if constexpr((detail::kLogMask & level) != 0) {
+    fmt::text_style style = {};
     char const* prefix = "[?]";
 
-    if constexpr(level == Trace) prefix = "\e[36m[T]";
-    if constexpr(level == Debug) prefix = "\e[34m[D]";
-    if constexpr(level ==  Info) prefix = "\e[37m[I]";
-    if constexpr(level ==  Warn) prefix = "\e[33m[W]";
-    if constexpr(level == Error) prefix = "\e[35m[E]";
-    if constexpr(level == Fatal) prefix = "\e[31m[F]";
+    if constexpr(level == Trace) {
+      style = fmt::fg(fmt::terminal_color::cyan);
+      prefix = "[T]";
+    }
+    if constexpr(level == Debug) {
+      style = fmt::fg(fmt::terminal_color::blue);
+      prefix = "[D]";
+    }
+    if constexpr(level ==  Info) {
+      prefix = "[I]";
+    }
+    if constexpr(level ==  Warn) {
+      style = fmt::fg(fmt::terminal_color::yellow);
+      prefix = "[W]";
+    }
+    if constexpr(level == Error) {
+      style = fmt::fg(fmt::terminal_color::magenta);
+      prefix = "[E]";
+    }
+    if constexpr(level == Fatal) {
+      style = fmt::fg(fmt::terminal_color::red);
+      prefix = "[F]";
+    }
 
-    fmt::print("{} {}\n", prefix, fmt::format(format, std::forward<Args>(args)...));
+    const auto& style_ref = style;
+    fmt::print(style_ref, "{} {}\n", prefix, fmt::format(format, std::forward<Args>(args)...));
   }
 }
 


### PR DESCRIPTION
I got somewhat tired of all-magenta terminal.

Before you merge - what do you think of dropping colouring of info messages (instead of painting them white)?
