### PR TITLE
APU: Add missing include

### DIFF
--- a/src/nba/src/hw/apu/apu.cpp
+++ b/src/nba/src/hw/apu/apu.cpp
@@ -5,6 +5,7 @@
  * Refer to the included LICENSE file.
  */
 
+#include <algorithm>
 #include <cmath>
 #include <nba/common/dsp/resampler/cosine.hpp>
 #include <nba/common/dsp/resampler/cubic.hpp>


### PR DESCRIPTION
Fixes the build on GCC 14.