### PR TITLE
Update .desktop file name passed to the QApplication

### DIFF
--- a/src/platform/qt/src/main.cpp
+++ b/src/platform/qt/src/main.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
 
   QCoreApplication::setOrganizationName("fleroviux");
   QCoreApplication::setApplicationName("NanoBoyAdvance");
-  QGuiApplication::setDesktopFileName("io.github.nba_emuNanoBoyAdvance");
+  QGuiApplication::setDesktopFileName("io.nanoboyadvance.NanoBoyAdvance");
 
   auto window = create_window(app, argc, argv);
   if(!window) {


### PR DESCRIPTION
Fixes the app having a generic W icon on Wayland desktops.